### PR TITLE
fix: use AWS_ROLE_ARN secret name to match Components repo convention

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install frontend dependencies


### PR DESCRIPTION
## Summary

One-line fix: `secrets.AWS_DEPLOY_ROLE_ARN` → `secrets.AWS_ROLE_ARN` in the Configure AWS credentials step.

The secret is configured as `AWS_ROLE_ARN` (matching the Components repo convention) but the workflow was referencing `AWS_DEPLOY_ROLE_ARN`, causing the OIDC step to silently receive an empty value and fail.

## Impact

Unblocks the `Deploy Admin UI` pipeline for PORTH-123 (QA subtasks PORTH-370, PORTH-388, PORTH-389) and PORTH-124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)