### PR TITLE
fix: resolve PORTH_API_URL dynamically from porth-components CloudFormation stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Resolve Porth API URL from CloudFormation
+        run: |
+          PORTH_API_URL=$(aws cloudformation describe-stacks \
+            --stack-name porth-components \
+            --query "Stacks[0].Outputs[?OutputKey=='PorthApiUrl'].OutputValue" \
+            --output text)
+          echo "PORTH_API_URL=$PORTH_API_URL" >> $GITHUB_ENV
+
       - name: Install frontend dependencies
         working-directory: frontend
         run: npm ci
@@ -52,7 +60,7 @@ jobs:
         run: npm run build
         env:
           # Auth0 config is fetched at runtime from GET /tenants/{tenantId} — no build-time secrets needed
-          VITE_API_BASE_URL: ${{ secrets.PORTH_API_URL }}
+          VITE_API_BASE_URL: ${{ env.PORTH_API_URL }}
 
       - name: SAM deploy (infrastructure)
         run: |
@@ -62,7 +70,7 @@ jobs:
             --capabilities CAPABILITY_IAM \
             --parameter-overrides \
               Environment=prod \
-              PorthApiUrl=${{ secrets.PORTH_API_URL }} \
+              PorthApiUrl=${{ env.PORTH_API_URL }} \
             --no-fail-on-empty-changeset
 
       - name: Resolve stack outputs


### PR DESCRIPTION
## Summary

- Removes `secrets.PORTH_API_URL` dependency (secret doesn't exist and was causing the deploy to fail with an empty value)
- Adds a "Resolve Porth API URL from CloudFormation" step after AWS credentials are configured — queries the `porth-components` stack's `PorthApiUrl` output and exports it to `GITHUB_ENV`
- Both `VITE_API_BASE_URL` (frontend build) and `PorthApiUrl` (SAM deploy parameter) now reference `${{ env.PORTH_API_URL }}`

Both repos deploy to the same AWS account (084847995635), so the credentials already in scope at that point can query the Components stack. This also means the URL self-updates if the Components stack is ever redeployed and the API Gateway ID changes.

Unblocks sample app deployment for PORTH-123 (QA) and PORTH-124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)