### PR TITLE
PORTH-127: correct API client endpoint paths and type field names

### DIFF
--- a/frontend/src/api/claimConfigs.ts
+++ b/frontend/src/api/claimConfigs.ts
@@ -2,10 +2,15 @@ import { apiClient } from './client'
 import type { ClaimMappingConfig } from './types'
 
 export const claimConfigsApi = {
-  getLatest: (tenantId: string, ns: string) => apiClient.get<ClaimMappingConfig>(`/claim-mapping-configs/${tenantId}/${ns}/latest`).then(r => r.data),
-  listVersions: (tenantId: string, ns: string) => apiClient.get<ClaimMappingConfig[]>(`/claim-mapping-configs/${tenantId}/${ns}/versions`).then(r => r.data),
-  getVersion: (tenantId: string, ns: string, v: number) => apiClient.get<ClaimMappingConfig>(`/claim-mapping-configs/${tenantId}/${ns}/${v}`).then(r => r.data),
-  create: (body: { tenant_id: string; app_namespace: string; mapping_source: Record<string, unknown>; example_jwt?: Record<string, unknown> }) =>
-    apiClient.post<ClaimMappingConfig>('/claim-mapping-configs/', body).then(r => r.data),
-  rollback: (tenantId: string, ns: string, v: number) => apiClient.post<ClaimMappingConfig>(`/claim-mapping-configs/${tenantId}/${ns}/rollback/${v}`).then(r => r.data),
+  getLatest: (tenantId: string) =>
+    apiClient.get<ClaimMappingConfig>(`/claim-mapping-configs/${tenantId}/latest`).then(r => r.data),
+  listVersions: (tenantId: string) =>
+    apiClient.get<ClaimMappingConfig[]>(`/claim-mapping-configs/${tenantId}/versions`).then(r => r.data),
+  getVersion: (tenantId: string, v: number) =>
+    apiClient.get<ClaimMappingConfig>(`/claim-mapping-configs/${tenantId}/${v}`).then(r => r.data),
+  /** Creates a new config version. tenant_id is a query param per API contract. */
+  create: (body: { tenant_id: string; mapping_source: Record<string, unknown>; example_jwt?: Record<string, unknown> }) =>
+    apiClient.post<ClaimMappingConfig>(`/claim-mapping-configs/`, body, { params: { tenant_id: body.tenant_id } }).then(r => r.data),
+  rollback: (tenantId: string, v: number) =>
+    apiClient.post<ClaimMappingConfig>(`/claim-mapping-configs/${tenantId}/rollback/${v}`).then(r => r.data),
 }

--- a/frontend/src/api/organizations.ts
+++ b/frontend/src/api/organizations.ts
@@ -1,10 +1,11 @@
 import { apiClient } from './client'
-import type { Organization, CreateOrganizationRequest, UpdateOrganizationRequest } from './types'
+import type { Organization, CreateOrganizationRequest, OrganizationCreateResponse, UpdateOrganizationRequest } from './types'
 
 export const organizationsApi = {
   list: () => apiClient.get<Organization[]>('/organizations/').then(r => r.data),
   get: (id: string) => apiClient.get<Organization>(`/organizations/${id}`).then(r => r.data),
   getBySlug: (slug: string) => apiClient.get<Organization>(`/organizations/slug/${slug}`).then(r => r.data),
-  create: (body: CreateOrganizationRequest) => apiClient.post<Organization>('/organizations/', body).then(r => r.data),
+  /** Creates org + first tenant atomically. Returns both in the response. */
+  create: (body: CreateOrganizationRequest) => apiClient.post<OrganizationCreateResponse>('/organizations/', body).then(r => r.data),
   update: (id: string, body: UpdateOrganizationRequest) => apiClient.patch<Organization>(`/organizations/${id}`, body).then(r => r.data),
 }

--- a/frontend/src/api/permissions.ts
+++ b/frontend/src/api/permissions.ts
@@ -1,11 +1,12 @@
 import { apiClient } from './client'
-import type { Permission } from './types'
+import type { Permission, BatchPermissionRequest, BatchPermissionResponse } from './types'
 
 export const permissionsApi = {
   list: (tenantId: string, appNamespace?: string, category?: string) =>
     apiClient.get<Permission[]>('/permissions/', { params: { tenant_id: tenantId, app_namespace: appNamespace, category } }).then(r => r.data),
   get: (tenantId: string, ns: string, key: string) =>
     apiClient.get<Permission>(`/permissions/${tenantId}/${ns}/${key}`).then(r => r.data),
-  register: (perms: Omit<Permission, 'id' | 'created_at'>[]) =>
-    apiClient.post<Permission[]>('/permissions/', perms).then(r => r.data),
+  /** Batch-register permissions. Body must include tenant_id, app_namespace, and permissions[]. */
+  register: (body: BatchPermissionRequest) =>
+    apiClient.post<BatchPermissionResponse>('/permissions/', body).then(r => r.data),
 }

--- a/frontend/src/api/roles.ts
+++ b/frontend/src/api/roles.ts
@@ -1,15 +1,20 @@
 import { apiClient } from './client'
-import type { Role, CreateRoleRequest, UpdateRoleRequest, Permission } from './types'
+import type { Role, CreateRoleRequest, UpdateRoleRequest } from './types'
 
 export const rolesApi = {
   list: (tenantId: string) => apiClient.get<Role[]>('/roles/', { params: { tenant_id: tenantId } }).then(r => r.data),
-  search: (tenantId: string, q?: string) => apiClient.get<Role[]>('/roles/search', { params: { tenant_id: tenantId, q } }).then(r => r.data),
+  search: (tenantId: string, q?: string, isSystem?: boolean) =>
+    apiClient.get<Role[]>('/roles/search', { params: { tenant_id: tenantId, q, is_system: isSystem } }).then(r => r.data),
   get: (tenantId: string, roleId: string) => apiClient.get<Role>(`/roles/${tenantId}/${roleId}`).then(r => r.data),
   create: (body: CreateRoleRequest) => apiClient.post<Role>('/roles/', body).then(r => r.data),
   update: (tenantId: string, roleId: string, body: UpdateRoleRequest) => apiClient.patch<Role>(`/roles/${tenantId}/${roleId}`, body).then(r => r.data),
   delete: (tenantId: string, roleId: string) => apiClient.delete(`/roles/${tenantId}/${roleId}`),
-  getPermissions: (tenantId: string, roleId: string) => apiClient.get<Permission[]>(`/roles/${tenantId}/${roleId}/permissions`).then(r => r.data),
-  setPermissions: (tenantId: string, roleId: string, keys: string[]) => apiClient.put<Permission[]>(`/roles/${tenantId}/${roleId}/permissions`, { permission_keys: keys }).then(r => r.data),
+  /** Returns permission keys (strings), not Permission objects. */
+  getPermissions: (tenantId: string, roleId: string) =>
+    apiClient.get<string[]>(`/roles/${tenantId}/${roleId}/permissions`).then(r => r.data),
+  /** Body is a raw string[] of permission keys — not a wrapped object. */
+  setPermissions: (tenantId: string, roleId: string, keys: string[]) =>
+    apiClient.put<{ message: string; role_id: string; permission_keys: string[] }>(`/roles/${tenantId}/${roleId}/permissions`, keys).then(r => r.data),
   assignToUser: (userId: string, tenantId: string, roleId: string) => apiClient.post(`/roles/users/${userId}/tenant/${tenantId}/roles/${roleId}`),
   removeFromUser: (userId: string, tenantId: string, roleId: string) => apiClient.delete(`/roles/users/${userId}/tenant/${tenantId}/roles/${roleId}`),
   getUserRoles: (userId: string, tenantId: string) => apiClient.get<Role[]>(`/roles/users/${userId}/tenant/${tenantId}/roles`).then(r => r.data),

--- a/frontend/src/api/tenants.ts
+++ b/frontend/src/api/tenants.ts
@@ -4,6 +4,10 @@ import type { Tenant, CreateTenantRequest, UpdateTenantRequest } from './types'
 export const tenantsApi = {
   listByOrg: (orgId: string) => apiClient.get<Tenant[]>(`/tenants/organization/${orgId}`).then(r => r.data),
   get: (id: string) => apiClient.get<Tenant>(`/tenants/${id}`).then(r => r.data),
-  create: (body: CreateTenantRequest) => apiClient.post<Tenant>('/tenants/', body).then(r => r.data),
+  /** Adds a tenant to an existing org. Uses PUT per API contract. */
+  create: (body: CreateTenantRequest) => apiClient.put<Tenant>('/tenants/', body).then(r => r.data),
   update: (id: string, body: UpdateTenantRequest) => apiClient.patch<Tenant>(`/tenants/${id}`, body).then(r => r.data),
+  suspend: (id: string) => apiClient.post<Tenant>(`/tenants/${id}/suspend`).then(r => r.data),
+  reactivate: (id: string) => apiClient.post<Tenant>(`/tenants/${id}/reactivate`).then(r => r.data),
+  decommission: (id: string) => apiClient.post<Tenant>(`/tenants/${id}/decommission`).then(r => r.data),
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -10,7 +10,13 @@ export interface Organization {
   id: string; name: string; slug: string; status: 'active' | 'suspended'
   idp_config?: IdpConfig; created_at: string; updated_at: string
 }
-export interface CreateOrganizationRequest { name: string; slug: string; idp_config?: IdpConfig }
+/** POST /organizations/ creates org + first tenant atomically. */
+export interface CreateOrganizationRequest {
+  name: string
+  slug: string
+  tenant: { org_id?: string; display_name: string; environment_type: 'production' | 'staging' | 'development' | 'sandbox' }
+}
+export interface OrganizationCreateResponse { organization: Organization; tenant: Tenant }
 export interface UpdateOrganizationRequest { name?: string; idp_config?: IdpConfig }
 
 // Tenants — field names match the Porth API Tenant model (PORTH-413)
@@ -98,10 +104,11 @@ export interface Permission {
 // Roles
 export interface Role {
   id: string; tenant_id: string; name: string; description?: string
-  is_system: boolean; created_at: string; updated_at: string
+  is_system: boolean; source_key?: string | string[]; created_at: string; updated_at: string
 }
-export interface CreateRoleRequest { tenant_id: string; name: string; description?: string }
-export interface UpdateRoleRequest { name?: string; description?: string }
+export interface CreateRoleRequest { tenant_id: string; name: string; description?: string; is_system?: boolean; source_key?: string | string[] }
+export interface UpdateRoleRequest { name?: string; description?: string; source_key?: string | string[] }
+export interface SetUserRolesRequest { tenant_id: string; role_ids: string[] }
 
 /**
  * PORTH-413: Single-call endpoint — provisions the user and returns the full
@@ -126,10 +133,20 @@ export interface CreateClaimRoleMappingRequest {
   claim_value: string; role_id: string; priority: number; is_active?: boolean
 }
 
+// Permissions — batch registration
+export interface PermissionRegistrationItem {
+  key: string; display_name: string; app_namespace: string
+  category?: string; description?: string; sort_order?: number
+}
+export interface BatchPermissionRequest {
+  tenant_id: string; app_namespace: string; permissions: PermissionRegistrationItem[]
+}
+export interface BatchPermissionResponse { registered: Permission[]; count: number }
+
 // Claim Mapping Configs
 export interface ClaimMappingConfig {
   id: string; tenant_id: string; app_namespace: string; version: number
-  mapping_source: Record<string, unknown>; compiled_ops?: unknown[]
+  mapping_source: Record<string, unknown>; compiled_source?: string
   compiled_hash?: string; example_jwt?: Record<string, unknown>
-  validation_report?: string; compiled_at?: string; created_at: string
+  validation_report?: string; created_at: string
 }

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client'
-import type { User, UpsertUserRequest, ProvisionRequest, ProvisionResponse, UserMeRequest, UserMeResponse } from './types'
+import type { User, UpsertUserRequest, ProvisionRequest, ProvisionResponse, UserMeRequest, UserMeResponse, Role, SetUserRolesRequest } from './types'
 
 export const usersApi = {
   listByTenant: (orgId: string, tenantId: string) =>
@@ -21,4 +21,10 @@ export const usersApi = {
   update: (id: string, body: Partial<UpsertUserRequest>) => apiClient.patch<User>(`/users/${id}`, body).then(r => r.data),
   suspend: (id: string) => apiClient.post<User>(`/users/${id}/suspend`).then(r => r.data),
   reactivate: (id: string) => apiClient.post<User>(`/users/${id}/reactivate`).then(r => r.data),
+  getUserRoles: (id: string, tenantId: string) =>
+    apiClient.get<Role[]>(`/users/${id}/roles`, { params: { tenant_id: tenantId } }).then(r => r.data),
+  setRoles: (id: string, body: SetUserRolesRequest) =>
+    apiClient.put<{ message: string }>(`/users/${id}/roles`, body).then(r => r.data),
+  getUserPermissions: (id: string, tenantId: string) =>
+    apiClient.get<string[]>(`/users/${id}/permissions`, { params: { tenant_id: tenantId } }).then(r => r.data),
 }


### PR DESCRIPTION
## Summary
- **organizations**: `create()` now returns `OrganizationCreateResponse` (org+tenant atomically); request body includes nested `tenant` field per API contract
- **tenants**: `create()` uses `PUT` not `POST`; adds `suspend`, `reactivate`, `decommission`
- **users**: adds `getUserRoles`, `setRoles`, `getUserPermissions` methods
- **roles**: `getPermissions` returns `string[]` not `Permission[]`; `setPermissions` sends raw `string[]` body not wrapped object; `search` accepts `is_system` param
- **permissions**: `register()` takes `BatchPermissionRequest` not a raw array
- **claimConfigs**: removes spurious `app_namespace` path segment from all URLs; `create` uses `?tenant_id=` query param per API contract
- **types**: adds `OrganizationCreateResponse`, `SetUserRolesRequest`, `BatchPermissionRequest`, `PermissionRegistrationItem`, `BatchPermissionResponse`; `Role` gains `source_key`; `ClaimMappingConfig` replaces `compiled_ops`/`compiled_at` with `compiled_source`

## Note
ESLint config file is missing from the repo — `npm run lint` fails with "couldn't find a configuration file". TypeScript type-check passes with 0 errors.

## Test plan
- [x] `npm run type-check` — 0 errors

🤖 Generated with Claude Code