### PR TITLE
PORTH-128: Organizations and Tenants admin screens

### DIFF
--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -1,13 +1,30 @@
-// PORTH-128 — Build Organization and Tenant management screens
-import { Link } from 'react-router-dom'
+// PORTH-128 — Organizations admin screen
+import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { organizationsApi } from '../api/organizations'
-import type { Organization } from '../api/types'
+import type { Organization, CreateOrganizationRequest } from '../api/types'
+
+const ENV_TYPES = ['production', 'staging', 'development', 'sandbox'] as const
+type EnvType = typeof ENV_TYPES[number]
+
+interface NewOrgForm {
+  name: string
+  slug: string
+  display_name: string
+  environment_type: EnvType
+}
+
+const EMPTY_FORM: NewOrgForm = { name: '', slug: '', display_name: '', environment_type: 'production' }
 
 export default function OrganizationsPage() {
+  const navigate = useNavigate()
   const [orgs, setOrgs] = useState<Organization[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [form, setForm] = useState<NewOrgForm>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   useEffect(() => {
     organizationsApi.list()
@@ -16,39 +33,171 @@ export default function OrganizationsPage() {
       .finally(() => setLoading(false))
   }, [])
 
-  if (loading) return <div className="text-gray-500 text-sm">Loading organizations…</div>
-  if (error)   return <div className="text-red-600 text-sm">Error: {error}</div>
+  function openModal() {
+    setForm(EMPTY_FORM)
+    setSubmitError(null)
+    setModalOpen(true)
+  }
+
+  function closeModal() {
+    setModalOpen(false)
+    setSubmitError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setSubmitError(null)
+    const body: CreateOrganizationRequest = {
+      name: form.name,
+      slug: form.slug,
+      tenant: { display_name: form.display_name, environment_type: form.environment_type },
+    }
+    try {
+      const result = await organizationsApi.create(body)
+      setOrgs(prev => [...prev, result.organization])
+      closeModal()
+    } catch (e: unknown) {
+      setSubmitError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Organizations</h1>
-        <button className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700">
+        <button
+          onClick={openModal}
+          className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700"
+        >
           + New Organization
         </button>
       </div>
-      {orgs.length === 0 ? (
-        <p className="text-gray-500 text-sm">No organizations yet.</p>
-      ) : (
-        <div className="grid gap-3">
-          {orgs.map(org => (
-            <Link
-              key={org.id}
-              to={`/admin/platform/organizations/${org.id}/tenants`}
-              className="bg-white border border-gray-200 rounded-lg px-5 py-4 flex items-center justify-between hover:border-indigo-300 transition-colors"
-            >
-              <div>
-                <p className="font-medium text-gray-900">{org.name}</p>
-                <p className="text-xs text-gray-400 mt-0.5">slug: {org.slug}</p>
-              </div>
-              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                org.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
-              }`}>{org.status}</span>
-            </Link>
-          ))}
+
+      {error && (
+        <div className="mb-4 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {error}
         </div>
       )}
-      <p className="mt-6 text-xs text-gray-400">Full create/edit forms — PORTH-128</p>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="animate-pulse bg-gray-200 rounded h-16 w-full" />
+          ))}
+        </div>
+      ) : orgs.length === 0 ? (
+        <p className="text-gray-500 text-sm">No organizations yet.</p>
+      ) : (
+        <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+          <thead className="bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wide">
+            <tr>
+              <th className="px-4 py-3">Name</th>
+              <th className="px-4 py-3">Slug</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3">Created</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {orgs.map(org => (
+              <tr
+                key={org.id}
+                onClick={() => navigate(`/admin/platform/organizations/${org.id}/tenants`)}
+                className="cursor-pointer hover:bg-indigo-50 transition-colors"
+              >
+                <td className="px-4 py-3 font-medium text-gray-900">{org.name}</td>
+                <td className="px-4 py-3 text-gray-500">{org.slug}</td>
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                    org.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                  }`}>
+                    {org.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-400">
+                  {new Date(org.created_at).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {/* New Organization Modal */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">New Organization</h2>
+            {submitError && (
+              <div className="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+                {submitError}
+              </div>
+            )}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                <input
+                  type="text"
+                  required
+                  value={form.name}
+                  onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Slug</label>
+                <input
+                  type="text"
+                  required
+                  value={form.slug}
+                  onChange={e => setForm(f => ({ ...f, slug: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">First Tenant Display Name</label>
+                <input
+                  type="text"
+                  required
+                  value={form.display_name}
+                  onChange={e => setForm(f => ({ ...f, display_name: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Environment Type</label>
+                <select
+                  value={form.environment_type}
+                  onChange={e => setForm(f => ({ ...f, environment_type: e.target.value as EnvType }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  {ENV_TYPES.map(t => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {submitting ? 'Creating…' : 'Create'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/TenantsPage.tsx
+++ b/frontend/src/pages/TenantsPage.tsx
@@ -1,41 +1,270 @@
-// PORTH-128 — Build Organization and Tenant management screens
-import { useParams, Link } from 'react-router-dom'
+// PORTH-128 — Tenants admin screen
+import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import { organizationsApi } from '../api/organizations'
 import { tenantsApi } from '../api/tenants'
-import type { Tenant } from '../api/types'
+import type { Organization, Tenant, CreateTenantRequest, UpdateTenantRequest } from '../api/types'
+
+const ENV_TYPES = ['production', 'staging', 'development', 'sandbox'] as const
+type EnvType = typeof ENV_TYPES[number]
+
+interface TenantForm {
+  display_name: string
+  environment_type: EnvType
+}
+
+const EMPTY_FORM: TenantForm = { display_name: '', environment_type: 'production' }
 
 export default function TenantsPage() {
   const { orgId } = useParams<{ orgId: string }>()
+
+  const [org, setOrg] = useState<Organization | null>(null)
   const [tenants, setTenants] = useState<Tenant[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editingTenant, setEditingTenant] = useState<Tenant | null>(null)
+  const [form, setForm] = useState<TenantForm>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (orgId) tenantsApi.listByOrg(orgId).then(setTenants).finally(() => setLoading(false))
+    if (!orgId) return
+    Promise.all([
+      organizationsApi.get(orgId),
+      tenantsApi.listByOrg(orgId),
+    ])
+      .then(([orgData, tenantData]) => {
+        setOrg(orgData)
+        setTenants(tenantData)
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
   }, [orgId])
 
-  if (loading) return <div className="text-gray-500 text-sm">Loading tenants…</div>
+  function openNewModal() {
+    setEditingTenant(null)
+    setForm(EMPTY_FORM)
+    setSubmitError(null)
+    setModalOpen(true)
+  }
+
+  function openEditModal(tenant: Tenant) {
+    setEditingTenant(tenant)
+    setForm({ display_name: tenant.display_name, environment_type: tenant.environment_type })
+    setSubmitError(null)
+    setModalOpen(true)
+  }
+
+  function closeModal() {
+    setModalOpen(false)
+    setEditingTenant(null)
+    setSubmitError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!orgId) return
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      if (editingTenant) {
+        const body: UpdateTenantRequest = { display_name: form.display_name }
+        const updated = await tenantsApi.update(editingTenant.tenant_id, body)
+        setTenants(prev => prev.map(t => t.tenant_id === updated.tenant_id ? updated : t))
+      } else {
+        const body: CreateTenantRequest = { org_id: orgId, display_name: form.display_name, environment_type: form.environment_type }
+        const created = await tenantsApi.create(body)
+        setTenants(prev => [...prev, created])
+      }
+      closeModal()
+    } catch (e: unknown) {
+      setSubmitError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleSuspend(tenant: Tenant) {
+    if (!window.confirm(`Suspend "${tenant.display_name}"? This will prevent users in this tenant from authenticating.`)) return
+    try {
+      const updated = await tenantsApi.suspend(tenant.tenant_id)
+      setTenants(prev => prev.map(t => t.tenant_id === updated.tenant_id ? updated : t))
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : 'Failed to suspend tenant')
+    }
+  }
+
+  async function handleReactivate(tenant: Tenant) {
+    if (!window.confirm(`Reactivate "${tenant.display_name}"?`)) return
+    try {
+      const updated = await tenantsApi.reactivate(tenant.tenant_id)
+      setTenants(prev => prev.map(t => t.tenant_id === updated.tenant_id ? updated : t))
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : 'Failed to reactivate tenant')
+    }
+  }
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Tenants</h1>
-        <button className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700">+ New Tenant</button>
-      </div>
-      <div className="grid gap-3">
-        {tenants.map(t => (
-          <Link key={t.tenant_id} to={`/admin/tenant/users`}
-            className="bg-white border border-gray-200 rounded-lg px-5 py-4 flex items-center justify-between hover:border-indigo-300 transition-colors">
+      {/* Org header */}
+      <div className="mb-6">
+        {loading ? (
+          <div className="animate-pulse bg-gray-200 rounded h-8 w-64" />
+        ) : org ? (
+          <div className="flex items-center gap-3">
             <div>
-              <p className="font-medium text-gray-900">{t.display_name}</p>
-              <p className="text-xs text-gray-400 mt-0.5">{t.environment_type}</p>
+              <h1 className="text-2xl font-bold text-gray-900">{org.name}</h1>
+              <p className="text-xs text-gray-400 mt-0.5">slug: {org.slug}</p>
             </div>
-            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-              t.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
-            }`}>{t.status}</span>
-          </Link>
-        ))}
+            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+              org.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+            }`}>
+              {org.status}
+            </span>
+          </div>
+        ) : null}
       </div>
-      <p className="mt-6 text-xs text-gray-400">Full create/edit forms — PORTH-128</p>
+
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-700">Tenants</h2>
+        <button
+          onClick={openNewModal}
+          className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700"
+        >
+          + New Tenant
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="animate-pulse bg-gray-200 rounded h-12 w-full" />
+          ))}
+        </div>
+      ) : tenants.length === 0 ? (
+        <p className="text-gray-500 text-sm">No tenants for this organization.</p>
+      ) : (
+        <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+          <thead className="bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wide">
+            <tr>
+              <th className="px-4 py-3">Display Name</th>
+              <th className="px-4 py-3">Environment</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3">Created</th>
+              <th className="px-4 py-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {tenants.map(tenant => (
+              <tr key={tenant.tenant_id} className="hover:bg-gray-50">
+                <td className="px-4 py-3 font-medium text-gray-900">{tenant.display_name}</td>
+                <td className="px-4 py-3 text-gray-500">{tenant.environment_type}</td>
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                    tenant.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                  }`}>
+                    {tenant.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-400">
+                  {new Date(tenant.created_at).toLocaleDateString()}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => openEditModal(tenant)}
+                      className="text-xs px-2 py-1 border border-gray-300 rounded hover:bg-gray-100 text-gray-600"
+                    >
+                      Edit
+                    </button>
+                    {tenant.status === 'active' ? (
+                      <button
+                        onClick={() => handleSuspend(tenant)}
+                        className="text-xs px-2 py-1 border border-red-200 rounded hover:bg-red-50 text-red-600"
+                      >
+                        Suspend
+                      </button>
+                    ) : tenant.status === 'suspended' ? (
+                      <button
+                        onClick={() => handleReactivate(tenant)}
+                        className="text-xs px-2 py-1 border border-green-200 rounded hover:bg-green-50 text-green-600"
+                      >
+                        Reactivate
+                      </button>
+                    ) : null}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {/* Create / Edit Tenant Modal */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              {editingTenant ? 'Edit Tenant' : 'New Tenant'}
+            </h2>
+            {submitError && (
+              <div className="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+                {submitError}
+              </div>
+            )}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+                <input
+                  type="text"
+                  required
+                  value={form.display_name}
+                  onChange={e => setForm(f => ({ ...f, display_name: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              {!editingTenant && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Environment Type</label>
+                  <select
+                    value={form.environment_type}
+                    onChange={e => setForm(f => ({ ...f, environment_type: e.target.value as EnvType }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  >
+                    {ENV_TYPES.map(t => (
+                      <option key={t} value={t}>{t}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {submitting ? (editingTenant ? 'Saving…' : 'Creating…') : (editingTenant ? 'Save' : 'Create')}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Implements `OrganizationsPage` — table view with Name, Slug, Status badge, Created Date; row click navigates to tenants; "New Organization" modal creates org+tenant atomically via `organizationsApi.create()`
- Implements `TenantsPage` — org header with name/slug/status; tenant table with Display Name, Environment Type, Status, Created Date, Actions; "New Tenant" and per-row "Edit" modals; inline Suspend/Reactivate buttons with `window.confirm` guard
- No external UI libraries — raw Tailwind throughout; skeleton pulse loaders; red alert banners for errors

## Test plan

- [ ] `/admin/platform/organizations` loads org list; skeleton shown during fetch; error banner on API failure
- [ ] "New Organization" modal: all fields required; submits and appends new row; cancel clears form
- [ ] Row click navigates to `/admin/platform/organizations/:orgId/tenants`
- [ ] Tenants page shows org header (name, slug, status badge) and tenant table
- [ ] "New Tenant" modal creates tenant; appended to table
- [ ] "Edit" pre-fills display name; saves update
- [ ] "Suspend" button only shown for active tenants; confirm dialog fires before API call
- [ ] "Reactivate" button only shown for suspended tenants; confirm dialog fires before API call
- [ ] TypeScript: `npm run type-check` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)