### PR TITLE
PORTH-132: Claim Role Mapping screen

### DIFF
--- a/frontend/src/pages/ClaimRoleMappingPage.tsx
+++ b/frontend/src/pages/ClaimRoleMappingPage.tsx
@@ -1,9 +1,312 @@
 // PORTH-132 — Claim-to-role mapping screen and JWT test evaluator
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { claimConfigsApi } from '../api/claimConfigs'
+import type { ClaimMappingConfig } from '../api/types'
+
+const DEFAULT_MAPPING_SOURCE = {
+  schema_version: '1',
+  fields: {
+    roles: {
+      claim_key: 'https://porth.io/roles',
+      ops: [{ op: 'resolve_roles' }],
+    },
+  },
+  default_roles: [] as string[],
+}
+
+interface EvalResult {
+  matchedRoles: string[]
+  unmatchedKeys: string[]
+}
+
+function evaluateClaims(
+  mappingSource: Record<string, unknown>,
+  claimsJson: string,
+): { result: EvalResult | null; error: string | null } {
+  let claims: Record<string, unknown>
+  try {
+    claims = JSON.parse(claimsJson) as Record<string, unknown>
+  } catch {
+    return { result: null, error: 'Invalid JSON — check the claims input.' }
+  }
+
+  const fields = (mappingSource.fields ?? {}) as Record<
+    string,
+    { claim_key?: string; ops?: Array<{ op: string }> }
+  >
+
+  // Collect all claim_keys referenced by resolve_roles fields
+  const referencedKeys = new Set<string>()
+  const matchedRoles: string[] = []
+
+  for (const fieldConfig of Object.values(fields)) {
+    const hasResolveRoles = (fieldConfig.ops ?? []).some(o => o.op === 'resolve_roles')
+    if (!hasResolveRoles || !fieldConfig.claim_key) continue
+
+    referencedKeys.add(fieldConfig.claim_key)
+    const claimValue = claims[fieldConfig.claim_key]
+    if (Array.isArray(claimValue)) {
+      for (const v of claimValue) {
+        if (typeof v === 'string') matchedRoles.push(v)
+      }
+    }
+  }
+
+  const unmatchedKeys = Object.keys(claims).filter(k => !referencedKeys.has(k))
+
+  return { result: { matchedRoles, unmatchedKeys }, error: null }
+}
+
 export default function ClaimRoleMappingPage() {
+  const [searchParams] = useSearchParams()
+  const tenantId = searchParams.get('tenantId') ?? ''
+
+  // Editor state
+  const [config, setConfig] = useState<ClaimMappingConfig | null>(null)
+  const [editorValue, setEditorValue] = useState<string>(
+    JSON.stringify(DEFAULT_MAPPING_SOURCE, null, 2),
+  )
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveSuccess, setSaveSuccess] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [jsonError, setJsonError] = useState<string | null>(null)
+
+  // JWT evaluator state
+  const [claimsInput, setClaimsInput] = useState('')
+  const [evalResult, setEvalResult] = useState<EvalResult | null>(null)
+  const [evalError, setEvalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!tenantId) {
+      setLoadError('No tenantId in URL.')
+      setLoading(false)
+      return
+    }
+    claimConfigsApi
+      .getLatest(tenantId)
+      .then(cfg => {
+        setConfig(cfg)
+        setEditorValue(JSON.stringify(cfg.mapping_source, null, 2))
+      })
+      .catch(() => {
+        // 404 or no config yet — keep default template
+      })
+      .finally(() => setLoading(false))
+  }, [tenantId])
+
+  function handleEditorChange(value: string) {
+    setEditorValue(value)
+    setJsonError(null)
+    setSaveSuccess(false)
+  }
+
+  async function handleSave() {
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(editorValue) as Record<string, unknown>
+    } catch {
+      setJsonError('Invalid JSON — fix the mapping config before saving.')
+      return
+    }
+
+    setSaving(true)
+    setSaveError(null)
+    setSaveSuccess(false)
+    try {
+      const updated = await claimConfigsApi.create({
+        tenant_id: tenantId,
+        mapping_source: parsed,
+      })
+      setConfig(updated)
+      setEditorValue(JSON.stringify(updated.mapping_source, null, 2))
+      setSaveSuccess(true)
+    } catch (e: unknown) {
+      setSaveError(e instanceof Error ? e.message : 'Save failed.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleEvaluate() {
+    setEvalResult(null)
+    setEvalError(null)
+
+    let mappingSource: Record<string, unknown>
+    try {
+      mappingSource = JSON.parse(editorValue) as Record<string, unknown>
+    } catch {
+      setEvalError('Mapping config JSON is invalid — fix it before evaluating.')
+      return
+    }
+
+    if (!claimsInput.trim()) {
+      setEvalError('Paste JWT claims JSON first.')
+      return
+    }
+
+    const { result, error } = evaluateClaims(mappingSource, claimsInput)
+    if (error) {
+      setEvalError(error)
+    } else {
+      setEvalResult(result)
+    }
+  }
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Claim-to-Role Mappings</h1>
-      <p className="text-gray-400 text-sm">Implementation pending (PORTH-132)</p>
+    <div className="max-w-3xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900 mb-1">Claim-to-Role Mappings</h1>
+        <p className="text-gray-500 text-sm">
+          Tenant: <span className="font-mono text-gray-700">{tenantId || '—'}</span>
+        </p>
+      </div>
+
+      {/* ── Mapping JSON Editor ─────────────────────────────────────────── */}
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold text-gray-800">Mapping Config JSON</h2>
+
+        {loadError && (
+          <div className="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+            {loadError}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="animate-pulse bg-gray-200 rounded h-64 w-full" />
+        ) : (
+          <>
+            <textarea
+              className="font-mono w-full h-64 border border-gray-300 rounded p-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              value={editorValue}
+              onChange={e => handleEditorChange(e.target.value)}
+              spellCheck={false}
+            />
+
+            {jsonError && (
+              <div className="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+                {jsonError}
+              </div>
+            )}
+
+            {config && (
+              <div className="text-xs text-gray-500 space-x-4">
+                <span>
+                  Version: <span className="font-medium text-gray-700">{config.version}</span>
+                </span>
+                {config.compiled_hash && (
+                  <span>
+                    Hash:{' '}
+                    <span className="font-mono text-gray-700">
+                      {config.compiled_hash.slice(0, 8)}
+                    </span>
+                  </span>
+                )}
+              </div>
+            )}
+
+            <p className="text-xs text-gray-400">
+              Edit the full mapping config JSON. Each save creates a new version.
+            </p>
+
+            {saveError && (
+              <div className="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+                {saveError}
+              </div>
+            )}
+
+            {saveSuccess && (
+              <div className="rounded-md bg-green-50 border border-green-200 px-3 py-2 text-sm text-green-700">
+                Saved — new version created.
+              </div>
+            )}
+
+            <button
+              onClick={handleSave}
+              disabled={saving || !tenantId}
+              className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </>
+        )}
+      </section>
+
+      {/* ── JWT Evaluator ───────────────────────────────────────────────── */}
+      <section className="space-y-3 border-t border-gray-200 pt-6">
+        <h2 className="text-base font-semibold text-gray-800">JWT Claims Evaluator</h2>
+        <p className="text-xs text-gray-400">
+          Client-side evaluation only — roles resolved against currently loaded mapping config.
+        </p>
+
+        <textarea
+          className="font-mono w-full h-40 border border-gray-300 rounded p-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          placeholder='Paste decoded JWT claims as JSON…'
+          value={claimsInput}
+          onChange={e => {
+            setClaimsInput(e.target.value)
+            setEvalResult(null)
+            setEvalError(null)
+          }}
+          spellCheck={false}
+        />
+
+        {evalError && (
+          <div className="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+            {evalError}
+          </div>
+        )}
+
+        <button
+          onClick={handleEvaluate}
+          disabled={loading}
+          className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+        >
+          Evaluate
+        </button>
+
+        {evalResult && (
+          <div className="space-y-4 pt-2">
+            <div>
+              <p className="text-sm font-medium text-gray-700 mb-2">Matched roles:</p>
+              {evalResult.matchedRoles.length === 0 ? (
+                <p className="text-sm text-gray-400">No roles matched.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {evalResult.matchedRoles.map(role => (
+                    <span
+                      key={role}
+                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
+                    >
+                      {role}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <p className="text-sm font-medium text-gray-700 mb-2">Unmatched claim fields:</p>
+              {evalResult.unmatchedKeys.length === 0 ? (
+                <p className="text-sm text-gray-400">All claim fields are referenced.</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {evalResult.unmatchedKeys.map(key => (
+                    <span
+                      key={key}
+                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600"
+                    >
+                      {key}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </section>
     </div>
   )
 }

--- a/frontend/src/pages/OrganizationsPage.tsx
+++ b/frontend/src/pages/OrganizationsPage.tsx
@@ -1,13 +1,30 @@
-// PORTH-128 — Build Organization and Tenant management screens
-import { Link } from 'react-router-dom'
+// PORTH-128 — Organizations admin screen
+import { useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { organizationsApi } from '../api/organizations'
-import type { Organization } from '../api/types'
+import type { Organization, CreateOrganizationRequest } from '../api/types'
+
+const ENV_TYPES = ['production', 'staging', 'development', 'sandbox'] as const
+type EnvType = typeof ENV_TYPES[number]
+
+interface NewOrgForm {
+  name: string
+  slug: string
+  display_name: string
+  environment_type: EnvType
+}
+
+const EMPTY_FORM: NewOrgForm = { name: '', slug: '', display_name: '', environment_type: 'production' }
 
 export default function OrganizationsPage() {
+  const navigate = useNavigate()
   const [orgs, setOrgs] = useState<Organization[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [form, setForm] = useState<NewOrgForm>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   useEffect(() => {
     organizationsApi.list()
@@ -16,39 +33,171 @@ export default function OrganizationsPage() {
       .finally(() => setLoading(false))
   }, [])
 
-  if (loading) return <div className="text-gray-500 text-sm">Loading organizations…</div>
-  if (error)   return <div className="text-red-600 text-sm">Error: {error}</div>
+  function openModal() {
+    setForm(EMPTY_FORM)
+    setSubmitError(null)
+    setModalOpen(true)
+  }
+
+  function closeModal() {
+    setModalOpen(false)
+    setSubmitError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setSubmitError(null)
+    const body: CreateOrganizationRequest = {
+      name: form.name,
+      slug: form.slug,
+      tenant: { display_name: form.display_name, environment_type: form.environment_type },
+    }
+    try {
+      const result = await organizationsApi.create(body)
+      setOrgs(prev => [...prev, result.organization])
+      closeModal()
+    } catch (e: unknown) {
+      setSubmitError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Organizations</h1>
-        <button className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700">
+        <button
+          onClick={openModal}
+          className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700"
+        >
           + New Organization
         </button>
       </div>
-      {orgs.length === 0 ? (
-        <p className="text-gray-500 text-sm">No organizations yet.</p>
-      ) : (
-        <div className="grid gap-3">
-          {orgs.map(org => (
-            <Link
-              key={org.id}
-              to={`/admin/platform/organizations/${org.id}/tenants`}
-              className="bg-white border border-gray-200 rounded-lg px-5 py-4 flex items-center justify-between hover:border-indigo-300 transition-colors"
-            >
-              <div>
-                <p className="font-medium text-gray-900">{org.name}</p>
-                <p className="text-xs text-gray-400 mt-0.5">slug: {org.slug}</p>
-              </div>
-              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                org.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
-              }`}>{org.status}</span>
-            </Link>
-          ))}
+
+      {error && (
+        <div className="mb-4 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {error}
         </div>
       )}
-      <p className="mt-6 text-xs text-gray-400">Full create/edit forms — PORTH-128</p>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="animate-pulse bg-gray-200 rounded h-16 w-full" />
+          ))}
+        </div>
+      ) : orgs.length === 0 ? (
+        <p className="text-gray-500 text-sm">No organizations yet.</p>
+      ) : (
+        <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+          <thead className="bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wide">
+            <tr>
+              <th className="px-4 py-3">Name</th>
+              <th className="px-4 py-3">Slug</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3">Created</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {orgs.map(org => (
+              <tr
+                key={org.id}
+                onClick={() => navigate(`/admin/platform/organizations/${org.id}/tenants`)}
+                className="cursor-pointer hover:bg-indigo-50 transition-colors"
+              >
+                <td className="px-4 py-3 font-medium text-gray-900">{org.name}</td>
+                <td className="px-4 py-3 text-gray-500">{org.slug}</td>
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                    org.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                  }`}>
+                    {org.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-400">
+                  {new Date(org.created_at).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {/* New Organization Modal */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">New Organization</h2>
+            {submitError && (
+              <div className="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+                {submitError}
+              </div>
+            )}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                <input
+                  type="text"
+                  required
+                  value={form.name}
+                  onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Slug</label>
+                <input
+                  type="text"
+                  required
+                  value={form.slug}
+                  onChange={e => setForm(f => ({ ...f, slug: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">First Tenant Display Name</label>
+                <input
+                  type="text"
+                  required
+                  value={form.display_name}
+                  onChange={e => setForm(f => ({ ...f, display_name: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Environment Type</label>
+                <select
+                  value={form.environment_type}
+                  onChange={e => setForm(f => ({ ...f, environment_type: e.target.value as EnvType }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                >
+                  {ENV_TYPES.map(t => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {submitting ? 'Creating…' : 'Create'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/TenantsPage.tsx
+++ b/frontend/src/pages/TenantsPage.tsx
@@ -1,41 +1,270 @@
-// PORTH-128 — Build Organization and Tenant management screens
-import { useParams, Link } from 'react-router-dom'
+// PORTH-128 — Tenants admin screen
+import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import { organizationsApi } from '../api/organizations'
 import { tenantsApi } from '../api/tenants'
-import type { Tenant } from '../api/types'
+import type { Organization, Tenant, CreateTenantRequest, UpdateTenantRequest } from '../api/types'
+
+const ENV_TYPES = ['production', 'staging', 'development', 'sandbox'] as const
+type EnvType = typeof ENV_TYPES[number]
+
+interface TenantForm {
+  display_name: string
+  environment_type: EnvType
+}
+
+const EMPTY_FORM: TenantForm = { display_name: '', environment_type: 'production' }
 
 export default function TenantsPage() {
   const { orgId } = useParams<{ orgId: string }>()
+
+  const [org, setOrg] = useState<Organization | null>(null)
   const [tenants, setTenants] = useState<Tenant[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editingTenant, setEditingTenant] = useState<Tenant | null>(null)
+  const [form, setForm] = useState<TenantForm>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (orgId) tenantsApi.listByOrg(orgId).then(setTenants).finally(() => setLoading(false))
+    if (!orgId) return
+    Promise.all([
+      organizationsApi.get(orgId),
+      tenantsApi.listByOrg(orgId),
+    ])
+      .then(([orgData, tenantData]) => {
+        setOrg(orgData)
+        setTenants(tenantData)
+      })
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
   }, [orgId])
 
-  if (loading) return <div className="text-gray-500 text-sm">Loading tenants…</div>
+  function openNewModal() {
+    setEditingTenant(null)
+    setForm(EMPTY_FORM)
+    setSubmitError(null)
+    setModalOpen(true)
+  }
+
+  function openEditModal(tenant: Tenant) {
+    setEditingTenant(tenant)
+    setForm({ display_name: tenant.display_name, environment_type: tenant.environment_type })
+    setSubmitError(null)
+    setModalOpen(true)
+  }
+
+  function closeModal() {
+    setModalOpen(false)
+    setEditingTenant(null)
+    setSubmitError(null)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!orgId) return
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      if (editingTenant) {
+        const body: UpdateTenantRequest = { display_name: form.display_name }
+        const updated = await tenantsApi.update(editingTenant.tenant_id, body)
+        setTenants(prev => prev.map(t => t.tenant_id === updated.tenant_id ? updated : t))
+      } else {
+        const body: CreateTenantRequest = { org_id: orgId, display_name: form.display_name, environment_type: form.environment_type }
+        const created = await tenantsApi.create(body)
+        setTenants(prev => [...prev, created])
+      }
+      closeModal()
+    } catch (e: unknown) {
+      setSubmitError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleSuspend(tenant: Tenant) {
+    if (!window.confirm(`Suspend "${tenant.display_name}"? This will prevent users in this tenant from authenticating.`)) return
+    try {
+      const updated = await tenantsApi.suspend(tenant.tenant_id)
+      setTenants(prev => prev.map(t => t.tenant_id === updated.tenant_id ? updated : t))
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : 'Failed to suspend tenant')
+    }
+  }
+
+  async function handleReactivate(tenant: Tenant) {
+    if (!window.confirm(`Reactivate "${tenant.display_name}"?`)) return
+    try {
+      const updated = await tenantsApi.reactivate(tenant.tenant_id)
+      setTenants(prev => prev.map(t => t.tenant_id === updated.tenant_id ? updated : t))
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : 'Failed to reactivate tenant')
+    }
+  }
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Tenants</h1>
-        <button className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700">+ New Tenant</button>
-      </div>
-      <div className="grid gap-3">
-        {tenants.map(t => (
-          <Link key={t.tenant_id} to={`/admin/tenant/users`}
-            className="bg-white border border-gray-200 rounded-lg px-5 py-4 flex items-center justify-between hover:border-indigo-300 transition-colors">
+      {/* Org header */}
+      <div className="mb-6">
+        {loading ? (
+          <div className="animate-pulse bg-gray-200 rounded h-8 w-64" />
+        ) : org ? (
+          <div className="flex items-center gap-3">
             <div>
-              <p className="font-medium text-gray-900">{t.display_name}</p>
-              <p className="text-xs text-gray-400 mt-0.5">{t.environment_type}</p>
+              <h1 className="text-2xl font-bold text-gray-900">{org.name}</h1>
+              <p className="text-xs text-gray-400 mt-0.5">slug: {org.slug}</p>
             </div>
-            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-              t.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
-            }`}>{t.status}</span>
-          </Link>
-        ))}
+            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+              org.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+            }`}>
+              {org.status}
+            </span>
+          </div>
+        ) : null}
       </div>
-      <p className="mt-6 text-xs text-gray-400">Full create/edit forms — PORTH-128</p>
+
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-700">Tenants</h2>
+        <button
+          onClick={openNewModal}
+          className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700"
+        >
+          + New Tenant
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="animate-pulse bg-gray-200 rounded h-12 w-full" />
+          ))}
+        </div>
+      ) : tenants.length === 0 ? (
+        <p className="text-gray-500 text-sm">No tenants for this organization.</p>
+      ) : (
+        <table className="w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+          <thead className="bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wide">
+            <tr>
+              <th className="px-4 py-3">Display Name</th>
+              <th className="px-4 py-3">Environment</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3">Created</th>
+              <th className="px-4 py-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 bg-white">
+            {tenants.map(tenant => (
+              <tr key={tenant.tenant_id} className="hover:bg-gray-50">
+                <td className="px-4 py-3 font-medium text-gray-900">{tenant.display_name}</td>
+                <td className="px-4 py-3 text-gray-500">{tenant.environment_type}</td>
+                <td className="px-4 py-3">
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                    tenant.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                  }`}>
+                    {tenant.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-400">
+                  {new Date(tenant.created_at).toLocaleDateString()}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => openEditModal(tenant)}
+                      className="text-xs px-2 py-1 border border-gray-300 rounded hover:bg-gray-100 text-gray-600"
+                    >
+                      Edit
+                    </button>
+                    {tenant.status === 'active' ? (
+                      <button
+                        onClick={() => handleSuspend(tenant)}
+                        className="text-xs px-2 py-1 border border-red-200 rounded hover:bg-red-50 text-red-600"
+                      >
+                        Suspend
+                      </button>
+                    ) : tenant.status === 'suspended' ? (
+                      <button
+                        onClick={() => handleReactivate(tenant)}
+                        className="text-xs px-2 py-1 border border-green-200 rounded hover:bg-green-50 text-green-600"
+                      >
+                        Reactivate
+                      </button>
+                    ) : null}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {/* Create / Edit Tenant Modal */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              {editingTenant ? 'Edit Tenant' : 'New Tenant'}
+            </h2>
+            {submitError && (
+              <div className="mb-3 rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+                {submitError}
+              </div>
+            )}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+                <input
+                  type="text"
+                  required
+                  value={form.display_name}
+                  onChange={e => setForm(f => ({ ...f, display_name: e.target.value }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              {!editingTenant && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Environment Type</label>
+                  <select
+                    value={form.environment_type}
+                    onChange={e => setForm(f => ({ ...f, environment_type: e.target.value as EnvType }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  >
+                    {ENV_TYPES.map(t => (
+                      <option key={t} value={t}>{t}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="px-4 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {submitting ? (editingTenant ? 'Saving…' : 'Creating…') : (editingTenant ? 'Save' : 'Create')}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,9 +1,325 @@
-// PORTH-129 — Build User management screen
+// PORTH-129 — User Management screen
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { usePorthContext } from '../context/PorthContext'
+import { usersApi } from '../api/users'
+import { rolesApi } from '../api/roles'
+import { tenantsApi } from '../api/tenants'
+import type { User, Role, Tenant } from '../api/types'
+
 export default function UsersPage() {
+  const { currentUser } = usePorthContext()
+  const orgId = currentUser?.porthUser.organization_id ?? ''
+
+  const [searchParams, setSearchParams] = useSearchParams()
+  const tenantId = searchParams.get('tenantId') ?? ''
+
+  // Tenant selector
+  const [tenants, setTenants] = useState<Tenant[]>([])
+  const [tenantsLoading, setTenantsLoading] = useState(false)
+
+  // User list
+  const [users, setUsers] = useState<User[]>([])
+  const [usersLoading, setUsersLoading] = useState(false)
+  const [usersError, setUsersError] = useState<string | null>(null)
+
+  // Email filter
+  const [emailFilter, setEmailFilter] = useState('')
+
+  // Side panel
+  const [selectedUser, setSelectedUser] = useState<User | null>(null)
+  const [panelRoles, setPanelRoles] = useState<Role[]>([]) // user's current roles
+  const [allRoles, setAllRoles] = useState<Role[]>([])     // all roles in tenant
+  const [rolesLoading, setRolesLoading] = useState(false)
+  const [selectedRoleIds, setSelectedRoleIds] = useState<string[]>([])
+  const [saving, setSaving] = useState(false)
+  const [suspending, setSuspending] = useState(false)
+
+  // Load tenants for org
+  useEffect(() => {
+    if (!orgId) return
+    setTenantsLoading(true)
+    tenantsApi.listByOrg(orgId).then(setTenants).finally(() => setTenantsLoading(false))
+  }, [orgId])
+
+  // Load users when tenantId changes
+  useEffect(() => {
+    if (!orgId || !tenantId) return
+    setUsersLoading(true)
+    setUsersError(null)
+    usersApi.listByTenant(orgId, tenantId)
+      .then(setUsers)
+      .catch(err => setUsersError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setUsersLoading(false))
+  }, [orgId, tenantId])
+
+  // Open side panel — load user roles and all tenant roles
+  function openPanel(user: User) {
+    setSelectedUser(user)
+    setRolesLoading(true)
+    setPanelRoles([])
+    setAllRoles([])
+    setSelectedRoleIds([])
+    Promise.all([
+      usersApi.getUserRoles(user.id, tenantId),
+      rolesApi.list(tenantId),
+    ])
+      .then(([userRoles, tenantRoles]) => {
+        setPanelRoles(userRoles)
+        setAllRoles(tenantRoles)
+        setSelectedRoleIds(userRoles.map(r => r.id))
+      })
+      .finally(() => setRolesLoading(false))
+  }
+
+  function closePanel() {
+    setSelectedUser(null)
+  }
+
+  async function handleSuspendToggle() {
+    if (!selectedUser) return
+    const action = selectedUser.status === 'active' ? 'suspend' : 'reactivate'
+    const verb = action === 'suspend' ? 'Suspend' : 'Reactivate'
+    if (!window.confirm(`${verb} ${selectedUser.display_name ?? selectedUser.email}?`)) return
+    setSuspending(true)
+    try {
+      const updated = action === 'suspend'
+        ? await usersApi.suspend(selectedUser.id)
+        : await usersApi.reactivate(selectedUser.id)
+      setUsers(prev => prev.map(u => u.id === updated.id ? updated : u))
+      setSelectedUser(updated)
+    } finally {
+      setSuspending(false)
+    }
+  }
+
+  async function handleSaveRoles() {
+    if (!selectedUser) return
+    setSaving(true)
+    try {
+      await usersApi.setRoles(selectedUser.id, { tenant_id: tenantId, role_ids: selectedRoleIds })
+      // Refresh displayed chips
+      const updated = allRoles.filter(r => selectedRoleIds.includes(r.id))
+      setPanelRoles(updated)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleTenantChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setSearchParams({ tenantId: e.target.value })
+    setSelectedUser(null)
+    setEmailFilter('')
+  }
+
+  function handleRoleSelectChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const ids = Array.from(e.target.selectedOptions).map(o => o.value)
+    setSelectedRoleIds(ids)
+  }
+
+  const filteredUsers = users.filter(u => {
+    const q = emailFilter.toLowerCase()
+    return !q || u.email.toLowerCase().includes(q) || (u.display_name ?? '').toLowerCase().includes(q)
+  })
+
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Users</h1>
-      <p className="text-gray-400 text-sm">Implementation pending (PORTH-129)</p>
+    <div className="relative">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Users</h1>
+      </div>
+
+      {/* Tenant selector */}
+      <div className="mb-5">
+        <label className="block text-xs font-medium text-gray-500 mb-1">Tenant</label>
+        {tenantsLoading ? (
+          <div className="animate-pulse bg-gray-200 rounded h-9 w-64" />
+        ) : (
+          <select
+            value={tenantId}
+            onChange={handleTenantChange}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 min-w-[260px]"
+          >
+            <option value="">— Select a tenant —</option>
+            {tenants.map(t => (
+              <option key={t.tenant_id} value={t.tenant_id}>
+                {t.display_name} ({t.environment_type})
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Email filter */}
+      {tenantId && (
+        <div className="mb-4">
+          <input
+            type="text"
+            placeholder="Search by email or name…"
+            value={emailFilter}
+            onChange={e => setEmailFilter(e.target.value)}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm w-64 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+      )}
+
+      {/* Error */}
+      {usersError && (
+        <div className="mb-4 px-4 py-3 bg-red-50 border border-red-300 text-red-700 rounded-lg text-sm">
+          {usersError}
+        </div>
+      )}
+
+      {/* User table */}
+      {tenantId && (
+        <div className={`bg-white border border-gray-200 rounded-lg overflow-hidden ${selectedUser ? 'mr-[380px]' : ''}`}>
+          {usersLoading ? (
+            <div className="p-6 space-y-3">
+              {[...Array(4)].map((_, i) => (
+                <div key={i} className="animate-pulse bg-gray-200 rounded h-6 w-full" />
+              ))}
+            </div>
+          ) : (
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Display Name</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Email</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Status</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {filteredUsers.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-8 text-center text-gray-400">No users found.</td>
+                  </tr>
+                ) : filteredUsers.map(user => (
+                  <tr
+                    key={user.id}
+                    onClick={() => openPanel(user)}
+                    className={`cursor-pointer hover:bg-indigo-50 transition-colors ${selectedUser?.id === user.id ? 'bg-indigo-50' : ''}`}
+                  >
+                    <td className="px-4 py-3 text-gray-900 font-medium">
+                      {user.display_name ?? (`${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() || '—')}
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{user.email}</td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={user.status} />
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">
+                      {new Date(user.created_at).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {!tenantId && !tenantsLoading && (
+        <p className="text-gray-400 text-sm mt-4">Select a tenant to view users.</p>
+      )}
+
+      {/* Side panel */}
+      {selectedUser && (
+        <div className="absolute top-0 right-0 w-[360px] bg-white border border-gray-200 rounded-lg shadow-xl flex flex-col">
+          {/* Header */}
+          <div className="flex items-start justify-between px-5 py-4 border-b border-gray-200">
+            <div>
+              <p className="font-semibold text-gray-900">
+                {selectedUser.display_name ?? (`${selectedUser.first_name ?? ''} ${selectedUser.last_name ?? ''}`.trim() || selectedUser.email)}
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">{selectedUser.email}</p>
+              <div className="mt-1.5">
+                <StatusBadge status={selectedUser.status} />
+              </div>
+            </div>
+            <button
+              onClick={closePanel}
+              className="text-gray-400 hover:text-gray-600 text-lg leading-none ml-3"
+              aria-label="Close panel"
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+            {/* Suspend / Reactivate */}
+            <div>
+              <button
+                onClick={handleSuspendToggle}
+                disabled={suspending}
+                className={`px-4 py-2 text-sm rounded-lg font-medium transition-colors disabled:opacity-60 ${
+                  selectedUser.status === 'active'
+                    ? 'bg-yellow-50 text-yellow-700 border border-yellow-300 hover:bg-yellow-100'
+                    : 'bg-green-50 text-green-700 border border-green-300 hover:bg-green-100'
+                }`}
+              >
+                {suspending ? 'Updating…' : selectedUser.status === 'active' ? 'Suspend User' : 'Reactivate User'}
+              </button>
+            </div>
+
+            {/* Current roles chips */}
+            <div>
+              <p className="text-xs font-medium text-gray-500 mb-2">Current Roles</p>
+              {rolesLoading ? (
+                <div className="animate-pulse bg-gray-200 rounded h-6 w-full" />
+              ) : panelRoles.length === 0 ? (
+                <p className="text-xs text-gray-400">No roles assigned.</p>
+              ) : (
+                <div className="flex flex-wrap gap-1.5">
+                  {panelRoles.map(r => (
+                    <span key={r.id} className="bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded-full">
+                      {r.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Role multi-select */}
+            <div>
+              <p className="text-xs font-medium text-gray-500 mb-2">Add / Edit Roles</p>
+              {rolesLoading ? (
+                <div className="animate-pulse bg-gray-200 rounded h-24 w-full" />
+              ) : (
+                <>
+                  <select
+                    multiple
+                    size={Math.min(allRoles.length + 1, 6)}
+                    value={selectedRoleIds}
+                    onChange={handleRoleSelectChange}
+                    className="w-full border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  >
+                    {allRoles.map(r => (
+                      <option key={r.id} value={r.id}>{r.name}</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-gray-400 mt-1">Hold ⌘/Ctrl to select multiple.</p>
+                  <button
+                    onClick={handleSaveRoles}
+                    disabled={saving}
+                    className="mt-3 w-full px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 disabled:opacity-60 font-medium"
+                  >
+                    {saving ? 'Saving…' : 'Save Roles'}
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
+  )
+}
+
+function StatusBadge({ status }: { status: 'active' | 'suspended' }) {
+  return (
+    <span className={`inline-block text-xs px-2 py-0.5 rounded-full font-medium ${
+      status === 'active' ? 'bg-green-100 text-green-700' : 'bg-yellow-100 text-yellow-700'
+    }`}>
+      {status}
+    </span>
   )
 }


### PR DESCRIPTION
## Summary
- Implements `ClaimRoleMappingPage.tsx` — JSON editor for the `ClaimMappingConfig.mapping_source` blob, with version/hash display and save-as-new-version behaviour
- On load, fetches the latest config via `claimConfigsApi.getLatest`; seeds from a default template if none exists (404)
- Client-side JWT claims evaluator: parses pasted claims JSON, walks `mapping_source.fields` for `resolve_roles` ops, and surfaces matched roles (green chips) and unmatched claim keys (grey chips)
- Raw Tailwind only — no external UI libraries

## Test plan
- [ ] Navigate to `/admin/tenant/claim-mappings?tenantId=<id>` — editor loads with existing config or default template
- [ ] Edit JSON and click Save — new version is created, version number and hash update
- [ ] Save with invalid JSON — red error shown, no API call made
- [ ] Paste valid JWT claims JSON and click Evaluate — matched roles shown in green, unmatched keys in grey
- [ ] Evaluate with invalid JSON — red error shown
- [ ] No `tenantId` in URL — load error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)