### PR TITLE
PORTH-133: Playwright E2E test suite

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,35 @@
+# ─── Local development ────────────────────────────────────────────────────────
+# Copy this file to frontend/.env.local and fill in real values.
+# Never commit .env.local — it is gitignored.
+
+# Base URL of the Porth API (no trailing slash)
+VITE_API_BASE_URL=https://api.your-stack.example.com
+
+# Tenant ID used when running on localhost (subdomain-based lookup is skipped)
+VITE_DEV_TENANT_ID=your-tenant-id
+
+# ─── E2E test bypass ──────────────────────────────────────────────────────────
+# Set to 'true' to skip Auth0 and inject a fake authenticated user.
+# The Playwright config sets this automatically via webServer.env — you do not
+# need to set it manually unless running the dev server yourself.
+VITE_E2E_AUTH=false
+
+# ─── Playwright / Tier 2 acceptance tests ─────────────────────────────────────
+# These are only needed for Tier 2 tests against the real deployed stack.
+# Set as GitHub Actions secrets for CI; locally store in a .env.tier2 file
+# that you source before running 'npx playwright test tests/e2e/tier2/'.
+
+# Full URL of the deployed frontend
+PLAYWRIGHT_BASE_URL=https://your-app.example.com
+
+# Platform admin credentials (Estyn operator — can create orgs and tenants)
+PORTH_PLATFORM_ADMIN_EMAIL=platform-admin@your-domain.com
+PORTH_PLATFORM_ADMIN_PASSWORD=
+
+# Tenant user credentials (has controller role in the test tenant)
+PORTH_TENANT_USER_EMAIL=tenant-user@your-domain.com
+PORTH_TENANT_USER_PASSWORD=
+
+# Viewer credentials (read-only role — no write permissions)
+PORTH_VIEWER_EMAIL=viewer@your-domain.com
+PORTH_VIEWER_PASSWORD=

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,46 @@
+name: E2E Tests
+on:
+  push:
+    branches: ['**']
+  pull_request:
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'npm', cache-dependency-path: 'frontend/package-lock.json' }
+      - run: npm ci
+        working-directory: frontend
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('frontend/package-lock.json') }}
+      - run: npx playwright install --with-deps chromium
+        working-directory: frontend
+      - name: Tier 1 tests
+        run: npx playwright test tests/e2e/tier1/
+        working-directory: frontend
+        env:
+          VITE_E2E_AUTH: 'true'
+          VITE_API_BASE_URL: 'http://localhost:5173'
+          VITE_DEV_TENANT_ID: 'test-tenant'
+      - name: Tier 2 tests (main branch only)
+        if: github.ref == 'refs/heads/main'
+        run: npx playwright test tests/e2e/tier2/
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PLAYWRIGHT_BASE_URL }}
+          PORTH_PLATFORM_ADMIN_EMAIL: ${{ secrets.PORTH_PLATFORM_ADMIN_EMAIL }}
+          PORTH_PLATFORM_ADMIN_PASSWORD: ${{ secrets.PORTH_PLATFORM_ADMIN_PASSWORD }}
+          PORTH_TENANT_USER_EMAIL: ${{ secrets.PORTH_TENANT_USER_EMAIL }}
+          PORTH_TENANT_USER_PASSWORD: ${{ secrets.PORTH_TENANT_USER_PASSWORD }}
+          PORTH_VIEWER_EMAIL: ${{ secrets.PORTH_VIEWER_EMAIL }}
+          PORTH_VIEWER_PASSWORD: ${{ secrets.PORTH_VIEWER_PASSWORD }}
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,8 @@
         "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
+        "@types/node": "^25.6.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
@@ -1008,6 +1010,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1425,6 +1443,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -3622,6 +3650,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -4381,6 +4456,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.2.4",
@@ -18,6 +19,8 @@
     "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^25.6.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.11.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    env: {
+      VITE_E2E_AUTH: 'true',
+      VITE_API_BASE_URL: 'http://localhost:5173',
+      VITE_DEV_TENANT_ID: 'test-tenant',
+    },
+  },
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,11 @@ import { useTenantConfig } from './hooks/useTenantConfig'
 import App from './App'
 import './index.css'
 
+// E2E test bypass: VITE_E2E_AUTH=true skips Auth0 and injects a fake authenticated
+// user so Playwright tests never redirect to the Auth0 login page.
+import { MockAuth0Provider } from './test-utils/MockAuth0Provider'
+const E2E_AUTH = import.meta.env.VITE_E2E_AUTH === 'true'
+
 function TenantBootstrap() {
   const { config, loading, error } = useTenantConfig()
 
@@ -23,6 +28,14 @@ function TenantBootstrap() {
           {error ?? 'Unable to load tenant configuration.'}
         </div>
       </div>
+    )
+  }
+
+  if (E2E_AUTH) {
+    return (
+      <MockAuth0Provider>
+        <App tenantConfig={config} />
+      </MockAuth0Provider>
     )
   }
 

--- a/frontend/src/test-utils/MockAuth0Provider.tsx
+++ b/frontend/src/test-utils/MockAuth0Provider.tsx
@@ -1,0 +1,47 @@
+/**
+ * E2E test bypass for Auth0.
+ *
+ * When VITE_E2E_AUTH=true this provider replaces Auth0Provider and returns a
+ * fake authenticated user so Playwright tests never hit the real Auth0 tenant.
+ *
+ * The injected user matches what mockCurrentUser() in the test helpers returns,
+ * so App.tsx sees isAuthenticated=true and calls POST /users/me (which tests
+ * mock via page.route).
+ */
+import { Auth0Context } from '@auth0/auth0-react'
+import type { ReactNode } from 'react'
+
+const FAKE_AUTH0_USER = {
+  sub: 'auth0|e2e-platform-admin',
+  email: 'platform-admin@e2e.test',
+  given_name: 'Platform',
+  family_name: 'Admin',
+  name: 'Platform Admin',
+  picture: '',
+  email_verified: true,
+  updated_at: '2024-01-01T00:00:00.000Z',
+}
+
+// Provides a minimal Auth0 context that satisfies all useAuth0() calls in the app.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ctx: any = {
+  isAuthenticated: true,
+  isLoading: false,
+  user: FAKE_AUTH0_USER,
+  error: undefined,
+  loginWithRedirect: () => Promise.resolve(),
+  loginWithPopup: () => Promise.resolve(),
+  logout: () => Promise.resolve(),
+  getAccessTokenSilently: () => Promise.resolve('e2e-fake-token'),
+  getAccessTokenWithPopup: () => Promise.resolve(undefined),
+  getIdTokenClaims: () => Promise.resolve(undefined),
+  handleRedirectCallback: () => Promise.resolve({ appState: undefined }),
+}
+
+export function MockAuth0Provider({ children }: { children: ReactNode }) {
+  return (
+    <Auth0Context.Provider value={ctx}>
+      {children}
+    </Auth0Context.Provider>
+  )
+}

--- a/frontend/tests/e2e/helpers/mocks.ts
+++ b/frontend/tests/e2e/helpers/mocks.ts
@@ -1,0 +1,407 @@
+// Shared mock helpers for Tier 1 E2E tests.
+// Call mockBootstrap(page) in every test to mock the two bootstrap calls:
+//   GET /tenants/test-tenant  -- tenant config (useTenantConfig)
+//   POST /users/me            -- current user + roles (useCurrentUser)
+// Route patterns use RegExp (not glob) so query strings are handled correctly.
+// Glob patterns like "**/roles/" do NOT match "/roles/?tenant_id=x".
+import type { Page } from '@playwright/test'
+import type {
+  Organization,
+  Tenant,
+  Role,
+  Permission,
+  User,
+  ClaimMappingConfig,
+} from '../../../src/api/types'
+
+// ─── Default fixture data ──────────────────────────────────────────────────
+
+export const DEFAULT_ORG: Organization = {
+  id: 'org-1',
+  name: 'Acme Corp',
+  slug: 'acme',
+  status: 'active',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+export const DEFAULT_ORG_2: Organization = {
+  id: 'org-2',
+  name: 'Beta Ltd',
+  slug: 'beta',
+  status: 'active',
+  created_at: '2024-01-02T00:00:00Z',
+  updated_at: '2024-01-02T00:00:00Z',
+}
+
+export const DEFAULT_TENANT: Tenant = {
+  tenant_id: 'test-tenant',
+  org_id: 'org-1',
+  org_name: 'Acme Corp',
+  display_name: 'Acme Production',
+  environment_type: 'production',
+  status: 'active',
+  idp_config_override: {
+    provider: 'auth0',
+    domain: 'e2e.eu.auth0.com',
+    client_id: 'e2e-client-id',
+    audience: 'https://e2e.api',
+  },
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+export const DEFAULT_SUSPENDED_TENANT: Tenant = {
+  ...DEFAULT_TENANT,
+  tenant_id: 'test-tenant-suspended',
+  display_name: 'Acme Staging',
+  status: 'suspended',
+}
+
+export const DEFAULT_PLATFORM_ADMIN_USER: User = {
+  id: 'user-platform-admin',
+  external_id: 'auth0|e2e-platform-admin',
+  email: 'platform-admin@e2e.test',
+  first_name: 'Platform',
+  last_name: 'Admin',
+  display_name: 'Platform Admin',
+  organization_id: 'org-1',
+  tenant_id: 'test-tenant',
+  status: 'active',
+  is_org_admin: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+export const DEFAULT_PLATFORM_ADMIN_ROLE: Role = {
+  id: 'role-platform-admin',
+  tenant_id: 'test-tenant',
+  name: 'platform-admin',
+  is_system: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+export const DEFAULT_SYSTEM_ROLE: Role = {
+  id: 'role-system-1',
+  tenant_id: 'test-tenant',
+  name: 'viewer',
+  description: 'Read-only access',
+  is_system: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+export const DEFAULT_CUSTOM_ROLE: Role = {
+  id: 'role-custom-1',
+  tenant_id: 'test-tenant',
+  name: 'ar_clerk',
+  description: 'AR data entry',
+  is_system: false,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+export const DEFAULT_PERMISSIONS: Permission[] = [
+  {
+    id: 'perm-1',
+    key: 'ar.invoices.read',
+    display_name: 'View Invoices',
+    app_namespace: 'sample',
+    category: 'Accounts Receivable',
+    sort_order: 1,
+    tenant_id: 'test-tenant',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'perm-2',
+    key: 'ar.invoices.write',
+    display_name: 'Create/Edit Invoices',
+    app_namespace: 'sample',
+    category: 'Accounts Receivable',
+    sort_order: 2,
+    tenant_id: 'test-tenant',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'perm-3',
+    key: 'ap.bills.read',
+    display_name: 'View Bills',
+    app_namespace: 'sample',
+    category: 'Accounts Payable',
+    sort_order: 1,
+    tenant_id: 'test-tenant',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'perm-4',
+    key: 'approvals.write',
+    display_name: 'Approve/Reject',
+    app_namespace: 'sample',
+    category: 'Approvals',
+    sort_order: 1,
+    tenant_id: 'test-tenant',
+    created_at: '2024-01-01T00:00:00Z',
+  },
+]
+
+export const DEFAULT_ACTIVE_USER: User = {
+  id: 'user-1',
+  external_id: 'auth0|user-1',
+  email: 'alice@acme.com',
+  first_name: 'Alice',
+  last_name: 'Smith',
+  display_name: 'Alice Smith',
+  organization_id: 'org-1',
+  tenant_id: 'test-tenant',
+  status: 'active',
+  is_org_admin: false,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+export const DEFAULT_SUSPENDED_USER: User = {
+  id: 'user-2',
+  external_id: 'auth0|user-2',
+  email: 'bob@acme.com',
+  first_name: 'Bob',
+  last_name: 'Jones',
+  display_name: 'Bob Jones',
+  organization_id: 'org-1',
+  tenant_id: 'test-tenant',
+  status: 'suspended',
+  is_org_admin: false,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+// DEFAULT_CLAIM_CONFIG uses the schema the ClaimRoleMappingPage evaluator understands:
+// { fields: { <name>: { claim_key: '...', ops: [{ op: 'resolve_roles' }] } } }
+export const DEFAULT_CLAIM_CONFIG: ClaimMappingConfig = {
+  id: 'config-1',
+  tenant_id: 'test-tenant',
+  app_namespace: 'sample',
+  version: 2,
+  mapping_source: {
+    schema_version: '1',
+    fields: {
+      roles: {
+        claim_key: 'https://porth.io/roles',
+        ops: [{ op: 'resolve_roles' }],
+      },
+    },
+    default_roles: [],
+  },
+  created_at: '2024-01-02T00:00:00Z',
+}
+
+export const DEFAULT_CLAIM_CONFIG_V1: ClaimMappingConfig = {
+  ...DEFAULT_CLAIM_CONFIG,
+  id: 'config-v1',
+  version: 1,
+  created_at: '2024-01-01T00:00:00Z',
+}
+
+// ─── Mock helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Mocks the two bootstrap calls every page needs:
+ *   GET /tenants/test-tenant  → tenant config (for useTenantConfig)
+ *   POST /users/me            → current user + roles (for useCurrentUser)
+ *
+ * @param permissions - explicit permission keys to inject; defaults to all DEFAULT_PERMISSIONS
+ */
+export async function mockBootstrap(
+  page: Page,
+  userOverrides?: Partial<User>,
+  roles?: Role[],
+  permissions?: string[],
+) {
+  // useTenantConfig calls plain fetch() not axios -- intercept by path
+  await page.route(/\/tenants\/test-tenant($|\?)/, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(DEFAULT_TENANT),
+    })
+  })
+
+  const resolvedUser = { ...DEFAULT_PLATFORM_ADMIN_USER, ...userOverrides }
+  const resolvedRoles = roles ?? [DEFAULT_PLATFORM_ADMIN_ROLE]
+  const resolvedPermissions = permissions ?? DEFAULT_PERMISSIONS.map(p => p.key)
+
+  await page.route(/\/users\/me($|\?)/, (route) => {
+    if (route.request().method() !== 'POST') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: resolvedUser,
+        is_new: false,
+        roles: resolvedRoles,
+        permissions: resolvedPermissions,
+      }),
+    })
+  })
+}
+
+export async function mockOrgs(page: Page, orgs: Organization[] = [DEFAULT_ORG, DEFAULT_ORG_2]) {
+  // Match GET /organizations/ (list endpoint).
+  await page.route(/\/organizations\/(\?.*)?$/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(orgs),
+    })
+  })
+}
+
+export async function mockOrg(page: Page, org: Organization = DEFAULT_ORG) {
+  await page.route(new RegExp(`/organizations/${org.id}($|\\?)`), (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(org),
+    })
+  })
+}
+
+export async function mockTenants(page: Page, tenants: Tenant[] = [DEFAULT_TENANT, DEFAULT_SUSPENDED_TENANT]) {
+  await page.route(/\/tenants\/organization\//, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(tenants),
+    })
+  })
+}
+
+export async function mockUsers(page: Page, users: User[] = [DEFAULT_ACTIVE_USER, DEFAULT_SUSPENDED_USER]) {
+  await page.route(/\/users\/organization\//, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(users),
+    })
+  })
+}
+
+export async function mockRoles(page: Page, roles: Role[] = [DEFAULT_SYSTEM_ROLE, DEFAULT_CUSTOM_ROLE]) {
+  // Matches /roles/ and /roles/?tenant_id=... but NOT /roles/tenant/role/permissions
+  await page.route(/\/roles\/($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(roles),
+    })
+  })
+}
+
+export async function mockRolePermissions(page: Page, keys: string[] = ['ar.invoices.read']) {
+  await page.route(/\/roles\/[^/]+\/[^/]+\/permissions($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(keys),
+    })
+  })
+}
+
+export async function mockPermissions(page: Page, permissions: Permission[] = DEFAULT_PERMISSIONS) {
+  await page.route(/\/permissions\/($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(permissions),
+    })
+  })
+}
+
+export async function mockClaimConfig(page: Page, config: ClaimMappingConfig = DEFAULT_CLAIM_CONFIG) {
+  await page.route(/\/claim-mapping-configs\/[^/]+\/latest($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(config),
+    })
+  })
+}
+
+export async function mockClaimConfigVersions(page: Page, versions: ClaimMappingConfig[] = [DEFAULT_CLAIM_CONFIG, DEFAULT_CLAIM_CONFIG_V1]) {
+  await page.route(/\/claim-mapping-configs\/[^/]+\/versions($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(versions),
+    })
+  })
+}
+
+/** Mocks the sample app API calls used by Dashboard / AR / AP / Approvals pages. */
+export async function mockSampleApis(page: Page) {
+  await page.route(/\/sample\/dashboard($|\?)/, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        outstanding_invoices: 5,
+        total_ar: 12500.0,
+        bills_due: 3,
+        total_ap: 4200.0,
+        pending_approvals: 1,
+        cash_position: 8300.0,
+      }),
+    })
+  })
+
+  await page.route(/\/sample\/ar\/invoices($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { invoice_id: 'inv-0001', customer_name: 'Widgets Inc', amount: '1200.00', status: 'sent', due_date: '2025-05-01' },
+        { invoice_id: 'inv-0002', customer_name: 'Gadgets Ltd', amount: '850.50', status: 'draft', due_date: '2025-06-15' },
+      ]),
+    })
+  })
+
+  await page.route(/\/sample\/ap\/bills($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { bill_id: 'bill-0001', vendor_name: 'Supplies Co', amount: '2300.00', status: 'pending', due_date: '2025-05-10' },
+        { bill_id: 'bill-0002', vendor_name: 'Services Ltd', amount: '1900.00', status: 'approved', due_date: '2025-05-20' },
+      ]),
+    })
+  })
+
+  await page.route(/\/sample\/approvals($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          record_id: 'rec-0001',
+          type: 'invoice',
+          amount: '1200.00',
+          submitted_by: 'alice@acme.com',
+          submitted_at: '2025-04-20T10:00:00Z',
+          status: 'pending',
+        },
+      ]),
+    })
+  })
+}

--- a/frontend/tests/e2e/tier1/ar-ap.spec.ts
+++ b/frontend/tests/e2e/tier1/ar-ap.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * AR / AP / Dashboard / Approvals screens
+ *
+ * These pages call the sample app API (/sample/*). We mock those endpoints
+ * alongside the Porth bootstrap calls.
+ */
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockSampleApis,
+  DEFAULT_PLATFORM_ADMIN_ROLE,
+  DEFAULT_SYSTEM_ROLE,
+} from '../helpers/mocks'
+import type { Role } from '../../../src/api/types'
+
+// A viewer role -- not in the allowed list for /approvals (controller only)
+const VIEWER_ROLE: Role = {
+  id: 'role-viewer',
+  tenant_id: 'test-tenant',
+  name: 'viewer',
+  is_system: true,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+test.describe('Dashboard', () => {
+  test('renders dashboard heading', async ({ page }) => {
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/dashboard')
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+  })
+
+  test('renders summary cards once API responds', async ({ page }) => {
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/dashboard')
+    // Card labels -- use exact match to avoid matching the subtitle text
+    await expect(page.getByText('Outstanding Invoices', { exact: true })).toBeVisible()
+    await expect(page.getByText('Bills Due', { exact: true })).toBeVisible()
+    await expect(page.getByText('Net Balance', { exact: true })).toBeVisible()
+  })
+})
+
+test.describe('AR page', () => {
+  test('renders Accounts Receivable heading', async ({ page }) => {
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/ar')
+    await expect(page.getByRole('heading', { name: 'Accounts Receivable' })).toBeVisible()
+  })
+
+  test('renders invoice table with mocked data', async ({ page }) => {
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/ar')
+    await expect(page.getByText('Widgets Inc')).toBeVisible()
+    await expect(page.getByText('Gadgets Ltd')).toBeVisible()
+  })
+
+  test('New Invoice button visible when user has ar.invoices.write permission', async ({ page }) => {
+    // mockBootstrap injects DEFAULT_PERMISSIONS which includes ar.invoices.write
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/ar')
+    await expect(page.getByRole('button', { name: 'New Invoice' })).toBeVisible()
+  })
+
+  test('New Invoice button hidden when user lacks ar.invoices.write permission', async ({ page }) => {
+    // Pass empty permissions -- user cannot write invoices
+    await mockBootstrap(page, undefined, [DEFAULT_PLATFORM_ADMIN_ROLE], [])
+    await mockSampleApis(page)
+    await page.goto('/ar')
+    await expect(page.getByRole('button', { name: 'New Invoice' })).not.toBeVisible()
+  })
+})
+
+test.describe('AP page', () => {
+  test('renders Accounts Payable heading', async ({ page }) => {
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/ap')
+    await expect(page.getByRole('heading', { name: 'Accounts Payable' })).toBeVisible()
+  })
+
+  test('renders bills table with mocked data', async ({ page }) => {
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/ap')
+    await expect(page.getByText('Supplies Co')).toBeVisible()
+    await expect(page.getByText('Services Ltd')).toBeVisible()
+  })
+})
+
+test.describe('Approvals page', () => {
+  test('renders Approvals heading', async ({ page }) => {
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/approvals')
+    await expect(page.getByRole('heading', { name: 'Approvals' })).toBeVisible()
+  })
+
+  test('renders Approve and Reject buttons for pending approval when user has approvals.write', async ({ page }) => {
+    // DEFAULT_PERMISSIONS includes approvals.write
+    await mockBootstrap(page)
+    await mockSampleApis(page)
+    await page.goto('/approvals')
+    await expect(page.getByRole('button', { name: 'Approve' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Reject' })).toBeVisible()
+  })
+
+  test('Approve/Reject buttons hidden when user lacks approvals.write', async ({ page }) => {
+    await mockBootstrap(page, undefined, [DEFAULT_PLATFORM_ADMIN_ROLE], [])
+    await mockSampleApis(page)
+    await page.goto('/approvals')
+    await expect(page.getByRole('button', { name: 'Approve' })).not.toBeVisible()
+    await expect(page.getByRole('button', { name: 'Reject' })).not.toBeVisible()
+  })
+})
+
+test.describe('Role-based route protection', () => {
+  test('viewer role is redirected from /approvals (controller-only route)', async ({ page }) => {
+    await mockBootstrap(page, undefined, [VIEWER_ROLE])
+    await page.goto('/approvals')
+    await expect(page).toHaveURL(/unauthorized/)
+  })
+
+  test('platform-admin can reach /approvals', async ({ page }) => {
+    await mockBootstrap(page, undefined, [DEFAULT_PLATFORM_ADMIN_ROLE])
+    await mockSampleApis(page)
+    await page.goto('/approvals')
+    await expect(page.getByRole('heading', { name: 'Approvals' })).toBeVisible()
+  })
+
+  test('viewer role can see /dashboard', async ({ page }) => {
+    await mockBootstrap(page, undefined, [
+      { ...DEFAULT_SYSTEM_ROLE, name: 'viewer' },
+    ])
+    await mockSampleApis(page)
+    await page.goto('/dashboard')
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/tier1/claim-mapping-config.spec.ts
+++ b/frontend/tests/e2e/tier1/claim-mapping-config.spec.ts
@@ -1,0 +1,52 @@
+// Claim Mapping Config page -- PORTH-131
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockClaimConfig,
+  mockClaimConfigVersions,
+} from '../helpers/mocks'
+
+test.describe('Claim Mapping Config page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page)
+    await mockClaimConfig(page)
+    await mockClaimConfigVersions(page)
+  })
+
+  test('renders Claim Mapping Config heading', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-config?tenantId=test-tenant')
+    await expect(page.getByRole('heading', { name: 'Claim Mapping Config' })).toBeVisible()
+  })
+
+  test('page is accessible as platform-admin', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-config?tenantId=test-tenant')
+    await expect(page).not.toHaveURL(/unauthorized/)
+  })
+
+  test('textarea contains the mapping JSON from the API', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-config?tenantId=test-tenant')
+    // The editor textarea should appear once loaded
+    await expect(page.locator('textarea').first()).toBeVisible()
+    // The textarea content is the mapping_source JSON
+    const content = await page.locator('textarea').first().inputValue()
+    expect(content).toContain('resolve_roles')
+  })
+
+  test('version history table shows 2 rows', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-config?tenantId=test-tenant')
+    await expect(page.getByRole('heading', { name: 'Version History' })).toBeVisible()
+    // Two Rollback buttons -- one per version
+    const rollbackButtons = page.getByRole('button', { name: 'Rollback' })
+    await expect(rollbackButtons).toHaveCount(2)
+  })
+
+  test('Compile Preview button is present', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-config?tenantId=test-tenant')
+    await expect(page.getByRole('button', { name: 'Compile Preview' })).toBeVisible()
+  })
+
+  test('Save button is present', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-config?tenantId=test-tenant')
+    await expect(page.getByRole('button', { name: 'Save' }).first()).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/tier1/claim-role-mapping.spec.ts
+++ b/frontend/tests/e2e/tier1/claim-role-mapping.spec.ts
@@ -1,0 +1,49 @@
+// Claim-to-Role Mapping page -- PORTH-132
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockClaimConfig,
+} from '../helpers/mocks'
+
+test.describe('Claim-to-Role Mapping page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page)
+    await mockClaimConfig(page)
+  })
+
+  test('renders Claim-to-Role Mappings heading', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-mappings?tenantId=test-tenant')
+    await expect(page.getByRole('heading', { name: 'Claim-to-Role Mappings' })).toBeVisible()
+  })
+
+  test('page is accessible as platform-admin', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-mappings?tenantId=test-tenant')
+    await expect(page).not.toHaveURL(/unauthorized/)
+  })
+
+  test('mapping editor textarea contains config JSON', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-mappings?tenantId=test-tenant')
+    // The first textarea is the mapping editor -- wait for it to have content
+    const mappingTextarea = page.locator('textarea').first()
+    await expect(mappingTextarea).toHaveValue(/resolve_roles/, { timeout: 8000 })
+  })
+
+  test('Evaluate button is present', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-mappings?tenantId=test-tenant')
+    await expect(page.getByRole('button', { name: 'Evaluate' })).toBeVisible()
+  })
+
+  test('JWT evaluator shows matched roles after evaluation', async ({ page }) => {
+    await page.goto('/admin/tenant/claim-mappings?tenantId=test-tenant')
+    // Wait for the mapping editor textarea to have content before evaluating
+    await expect(page.locator('textarea').first()).toHaveValue(/resolve_roles/, { timeout: 8000 })
+    // The evaluator textarea has a specific placeholder
+    const evaluatorTextarea = page.getByPlaceholder('Paste decoded JWT claims as JSON')
+    await evaluatorTextarea.fill('{"https://porth.io/roles": ["controller"]}')
+    await page.getByRole('button', { name: 'Evaluate' }).click()
+    // Matched roles section should appear
+    await expect(page.getByText('Matched roles:', { exact: true })).toBeVisible()
+    // The matched role 'controller' appears -- use getByRole for the badge
+    await expect(page.getByText('controller', { exact: true })).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/tier1/organizations.spec.ts
+++ b/frontend/tests/e2e/tier1/organizations.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockOrgs,
+  DEFAULT_ORG,
+  DEFAULT_ORG_2,
+} from '../helpers/mocks'
+
+test.describe('Organizations page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page)
+    await mockOrgs(page)
+  })
+
+  test('renders org list with names and slugs', async ({ page }) => {
+    await page.goto('/admin/platform/organizations')
+    await expect(page.getByRole('heading', { name: 'Organizations' })).toBeVisible()
+    // Wait for org rows to appear (API response loaded)
+    await expect(page.getByRole('cell', { name: DEFAULT_ORG.name })).toBeVisible()
+    await expect(page.getByRole('cell', { name: DEFAULT_ORG_2.name })).toBeVisible()
+    // Slug column renders the raw slug value (exact to avoid partial match with org name)
+    await expect(page.getByRole('cell', { name: DEFAULT_ORG.slug, exact: true })).toBeVisible()
+  })
+
+  test('New Organization button is visible', async ({ page }) => {
+    await page.goto('/admin/platform/organizations')
+    await expect(page.getByRole('button', { name: '+ New Organization' })).toBeVisible()
+  })
+
+  test('clicking an org row navigates to its tenants page', async ({ page }) => {
+    await page.goto('/admin/platform/organizations')
+    // Each org is a Link -- click on the first org name
+    await page.getByText(DEFAULT_ORG.name).click()
+    await expect(page).toHaveURL(new RegExp(`/admin/platform/organizations/${DEFAULT_ORG.id}/tenants`))
+  })
+})

--- a/frontend/tests/e2e/tier1/permissions.spec.ts
+++ b/frontend/tests/e2e/tier1/permissions.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockPermissions,
+  DEFAULT_PERMISSIONS,
+} from '../helpers/mocks'
+
+test.describe('Permissions page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page)
+    await mockPermissions(page)
+  })
+
+  test('renders permissions heading', async ({ page }) => {
+    await page.goto('/admin/tenant/permissions?tenantId=test-tenant')
+    await expect(page.getByRole('heading', { name: 'Permissions' })).toBeVisible()
+  })
+
+  test('renders grouped category headers', async ({ page }) => {
+    await page.goto('/admin/tenant/permissions?tenantId=test-tenant')
+    // Categories from DEFAULT_PERMISSIONS: Accounts Receivable, Accounts Payable, Approvals
+    await expect(page.getByText('Accounts Receivable', { exact: false }).first()).toBeVisible()
+    await expect(page.getByText('Accounts Payable', { exact: false }).first()).toBeVisible()
+    await expect(page.getByText('Approvals', { exact: false }).first()).toBeVisible()
+  })
+
+  test('renders permission display names', async ({ page }) => {
+    await page.goto('/admin/tenant/permissions?tenantId=test-tenant')
+    for (const perm of DEFAULT_PERMISSIONS) {
+      await expect(page.getByText(perm.display_name)).toBeVisible()
+    }
+  })
+
+  test('no create/edit/delete buttons present (read-only screen)', async ({ page }) => {
+    await page.goto('/admin/tenant/permissions?tenantId=test-tenant')
+    await expect(page.getByRole('button', { name: /new|create|edit|delete/i })).not.toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/tier1/roles.spec.ts
+++ b/frontend/tests/e2e/tier1/roles.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockRoles,
+  mockPermissions,
+  mockRolePermissions,
+  DEFAULT_SYSTEM_ROLE,
+  DEFAULT_CUSTOM_ROLE,
+} from '../helpers/mocks'
+
+test.describe('Roles page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page)
+    await mockRoles(page)
+    await mockPermissions(page)
+    await mockRolePermissions(page)
+  })
+
+  test('renders roles table with both roles', async ({ page }) => {
+    await page.goto('/admin/tenant/roles?tenantId=test-tenant')
+    await expect(page.getByRole('heading', { name: 'Roles' })).toBeVisible()
+    await expect(page.getByText(DEFAULT_SYSTEM_ROLE.name)).toBeVisible()
+    await expect(page.getByText(DEFAULT_CUSTOM_ROLE.name)).toBeVisible()
+  })
+
+  test('system role shows system badge', async ({ page }) => {
+    await page.goto('/admin/tenant/roles?tenantId=test-tenant')
+    // The system role row has a "system" badge
+    await expect(page.getByText('system').first()).toBeVisible()
+  })
+
+  test('clicking custom role opens side panel with permissions checklist', async ({ page }) => {
+    await page.goto('/admin/tenant/roles?tenantId=test-tenant')
+    // Click the custom role row
+    await page.getByText(DEFAULT_CUSTOM_ROLE.name).click()
+    // Side panel heading
+    await expect(page.getByRole('heading', { name: DEFAULT_CUSTOM_ROLE.name })).toBeVisible()
+    // Delete Role button should be present for non-system roles
+    await expect(page.getByRole('button', { name: 'Delete Role' })).toBeVisible()
+    // Save Permissions button should be present
+    await expect(page.getByRole('button', { name: 'Save Permissions' })).toBeVisible()
+  })
+
+  test('clicking system role does NOT show Delete button', async ({ page }) => {
+    await page.goto('/admin/tenant/roles?tenantId=test-tenant')
+    await page.getByText(DEFAULT_SYSTEM_ROLE.name).click()
+    // Panel should open
+    await expect(page.getByRole('heading', { name: DEFAULT_SYSTEM_ROLE.name })).toBeVisible()
+    // Delete button must NOT appear for system roles
+    await expect(page.getByRole('button', { name: 'Delete Role' })).not.toBeVisible()
+  })
+
+  test('New Role button is visible', async ({ page }) => {
+    await page.goto('/admin/tenant/roles?tenantId=test-tenant')
+    await expect(page.getByRole('button', { name: '+ New Role' })).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/tier1/tenants.spec.ts
+++ b/frontend/tests/e2e/tier1/tenants.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockTenants,
+  DEFAULT_TENANT,
+  DEFAULT_SUSPENDED_TENANT,
+} from '../helpers/mocks'
+
+test.describe('Tenants page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page)
+    await mockTenants(page)
+  })
+
+  test('renders tenants list for an org', async ({ page }) => {
+    await page.goto('/admin/platform/organizations/org-1/tenants')
+    await expect(page.getByRole('heading', { name: 'Tenants' })).toBeVisible()
+    await expect(page.getByText(DEFAULT_TENANT.display_name)).toBeVisible()
+    await expect(page.getByText(DEFAULT_SUSPENDED_TENANT.display_name)).toBeVisible()
+  })
+
+  test('New Tenant button is visible', async ({ page }) => {
+    await page.goto('/admin/platform/organizations/org-1/tenants')
+    await expect(page.getByRole('button', { name: '+ New Tenant' })).toBeVisible()
+  })
+
+  test('active tenant shows active status badge', async ({ page }) => {
+    await page.goto('/admin/platform/organizations/org-1/tenants')
+    // The active tenant row has an 'active' badge
+    await expect(page.locator('text=active').first()).toBeVisible()
+  })
+
+  test('suspended tenant shows suspended status badge', async ({ page }) => {
+    await page.goto('/admin/platform/organizations/org-1/tenants')
+    await expect(page.getByText('suspended')).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/tier1/users.spec.ts
+++ b/frontend/tests/e2e/tier1/users.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+import {
+  mockBootstrap,
+  mockTenants,
+  mockUsers,
+  mockRoles,
+  mockRolePermissions,
+  DEFAULT_ACTIVE_USER,
+  DEFAULT_SUSPENDED_USER,
+  DEFAULT_TENANT,
+} from '../helpers/mocks'
+
+// The page also needs user-level role endpoints when side panel opens
+async function mockUserRoles(page: import('@playwright/test').Page) {
+  await page.route(/\/users\/[^/]+\/roles($|\?)/, (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  })
+}
+
+test.describe('Users page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page)
+    await mockTenants(page)
+    await mockUsers(page)
+    await mockRoles(page)
+    await mockRolePermissions(page)
+    await mockUserRoles(page)
+  })
+
+  test('renders Users heading', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible()
+  })
+
+  test('page is accessible as platform-admin', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await expect(page).not.toHaveURL(/unauthorized/)
+  })
+
+  test('renders tenant selector', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await expect(page.getByRole('combobox')).toBeVisible()
+  })
+
+  test('renders user table with both users', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await expect(page.getByText(DEFAULT_ACTIVE_USER.display_name!)).toBeVisible()
+    await expect(page.getByText(DEFAULT_SUSPENDED_USER.display_name!)).toBeVisible()
+  })
+
+  test('active user shows active status badge', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    // active badge from StatusBadge component
+    await expect(page.getByText('active').first()).toBeVisible()
+  })
+
+  test('clicking user row opens side panel with email and suspend button', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await page.getByText(DEFAULT_ACTIVE_USER.display_name!).first().click()
+    // Side panel shows the Suspend User button
+    await expect(page.getByRole('button', { name: 'Suspend User' })).toBeVisible()
+    // Side panel shows email (may appear in table too -- use first match)
+    await expect(page.getByText(DEFAULT_ACTIVE_USER.email).first()).toBeVisible()
+  })
+
+  test('clicking suspended user shows Reactivate button', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await page.getByText(DEFAULT_SUSPENDED_USER.display_name!).click()
+    await expect(page.getByRole('button', { name: 'Reactivate User' })).toBeVisible()
+  })
+
+  test('Save Roles button is present in the side panel', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await page.getByText(DEFAULT_ACTIVE_USER.display_name!).click()
+    await expect(page.getByRole('button', { name: 'Save Roles' })).toBeVisible()
+  })
+
+  test('tenant selector shows the mocked tenants', async ({ page }) => {
+    await page.goto('/admin/tenant/users?tenantId=test-tenant')
+    await expect(page.getByRole('option', { name: new RegExp(DEFAULT_TENANT.display_name) })).toBeAttached()
+  })
+})

--- a/frontend/tests/e2e/tier2/acceptance.spec.ts
+++ b/frontend/tests/e2e/tier2/acceptance.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Tier 2 -- Acceptance tests against the real deployed stack.
+ *
+ * These tests require real credentials provided via environment variables.
+ * They run on the main branch only (see .github/workflows/e2e.yml).
+ *
+ * Required env vars (see .env.local.example):
+ *   PLAYWRIGHT_BASE_URL
+ *   PORTH_PLATFORM_ADMIN_EMAIL / PORTH_PLATFORM_ADMIN_PASSWORD
+ *   PORTH_TENANT_USER_EMAIL / PORTH_TENANT_USER_PASSWORD
+ *   PORTH_VIEWER_EMAIL / PORTH_VIEWER_PASSWORD
+ */
+import { test, expect } from '@playwright/test'
+
+const PLATFORM_ADMIN_EMAIL = process.env.PORTH_PLATFORM_ADMIN_EMAIL ?? ''
+const PLATFORM_ADMIN_PASSWORD = process.env.PORTH_PLATFORM_ADMIN_PASSWORD ?? ''
+const TENANT_USER_EMAIL = process.env.PORTH_TENANT_USER_EMAIL ?? ''
+const TENANT_USER_PASSWORD = process.env.PORTH_TENANT_USER_PASSWORD ?? ''
+const VIEWER_EMAIL = process.env.PORTH_VIEWER_EMAIL ?? ''
+const VIEWER_PASSWORD = process.env.PORTH_VIEWER_PASSWORD ?? ''
+
+/** Signs in via the Auth0 Universal Login page. */
+async function signIn(page: import('@playwright/test').Page, email: string, password: string) {
+  // The app shows a "Sign in" button when unauthenticated (Layout.tsx)
+  await page.getByRole('button', { name: 'Sign in' }).click()
+  // Auth0 Universal Login
+  await page.waitForURL(/auth0\.com|eu\.auth0\.com/)
+  await page.getByLabel('Email address').fill(email)
+  await page.getByLabel('Password').fill(password)
+  await page.getByRole('button', { name: 'Continue' }).click()
+  // Wait for redirect back to app
+  await page.waitForURL(new RegExp(process.env.PLAYWRIGHT_BASE_URL ?? 'localhost'))
+}
+
+test.describe.serial('Acceptance', () => {
+  test('platform admin can create org and tenant', async ({ page }) => {
+    await page.goto('/')
+    await signIn(page, PLATFORM_ADMIN_EMAIL, PLATFORM_ADMIN_PASSWORD)
+    // Platform admin lands on organizations page
+    await expect(page).toHaveURL(/\/admin\/platform\/organizations/)
+    await expect(page.getByRole('heading', { name: 'Organizations' })).toBeVisible()
+    // New Organization button present
+    await expect(page.getByRole('button', { name: /New Organization/i })).toBeVisible()
+  })
+
+  test('tenant user is provisioned and sees dashboard', async ({ page }) => {
+    await page.goto('/')
+    await signIn(page, TENANT_USER_EMAIL, TENANT_USER_PASSWORD)
+    // Tenant users redirect to dashboard
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+  })
+
+  test('controller can create invoice', async ({ page }) => {
+    await page.goto('/')
+    await signIn(page, TENANT_USER_EMAIL, TENANT_USER_PASSWORD)
+    await page.goto('/ar')
+    await expect(page.getByRole('heading', { name: 'Accounts Receivable' })).toBeVisible()
+    // When AR screen is fully implemented, a "New Invoice" button will be visible
+    // for controller role. Loose assertion for now:
+    await expect(page).toHaveURL(/\/ar/)
+  })
+
+  test('viewer cannot see New Invoice button', async ({ page }) => {
+    await page.goto('/')
+    await signIn(page, VIEWER_EMAIL, VIEWER_PASSWORD)
+    await page.goto('/ar')
+    // Viewer has no ar_clerk or controller role -- redirected to /unauthorized
+    // or AR screen renders without a write-action button
+    const url = page.url()
+    const isUnauthorized = url.includes('unauthorized')
+    if (!isUnauthorized) {
+      // If viewer can see the AR page, the New Invoice button must not be present
+      await expect(page.getByRole('button', { name: /New Invoice/i })).not.toBeVisible()
+    } else {
+      await expect(page).toHaveURL(/unauthorized/)
+    }
+  })
+})

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "types": ["node", "@playwright/test"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"] }
+  },
+  "include": ["tests/e2e/**/*.ts", "src/api/types.ts", "playwright.config.ts"]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Adds a complete Playwright E2E test suite with two tiers: Tier 1 (50 fully mocked tests, no real API) and Tier 2 (acceptance tests against the deployed stack, main branch only)
- Introduces `MockAuth0Provider` activated by `VITE_E2E_AUTH=true` to bypass Auth0 in Playwright runs — dev server boots with this flag set via `playwright.config.ts` `webServer.env`
- All network calls (tenant bootstrap, user provisioning, page-specific APIs) are intercepted via `page.route()` with RegExp patterns that correctly handle query strings

## Test coverage (Tier 1)

| Spec | Tests |
|---|---|
| organizations.spec.ts | Table renders, slug column, New Org button, row-click navigation |
| tenants.spec.ts | Table renders, New Tenant button, active/suspended badges |
| users.spec.ts | Table, side panel open, Suspend/Reactivate, Save Roles |
| roles.spec.ts | Table, system badge, custom role side panel, Delete visible/hidden |
| permissions.spec.ts | Category headers, read-only (no create/edit/delete buttons) |
| claim-mapping-config.spec.ts | Editor textarea content, version history, Rollback buttons, Compile Preview |
| claim-role-mapping.spec.ts | Editor textarea, JWT evaluator matched-roles output |
| ar-ap.spec.ts | Dashboard cards, AR/AP tables, New Invoice perm-gating, Approve/Reject perm-gating, route protection |

## Test plan

- [x] All 50 Tier 1 tests pass locally (`npx playwright test tests/e2e/tier1/`)
- [x] `npm run type-check` passes (src + e2e tsconfig)
- [x] Tier 2 acceptance spec compiles clean (`tsc --noEmit --project tsconfig.e2e.json`)
- [ ] GitHub Actions `e2e.yml` workflow runs Tier 1 on all branches, Tier 2 on main only (secrets not yet configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)