### PR TITLE
[PORTH-444] Fix deploy.yml post-test re-seed gate + adapt api-tests to PORTH-443

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,7 +251,10 @@ jobs:
           EOF
 
       # ── Step 7: Bootstrap platform tenant (post-test) ────────────────────────────
+      # always() — a failed E2E step above must still re-seed the tables that the
+      # post-test cleanup (also always()) just wiped, or DynamoDB is left empty.
       - name: Bootstrap platform tenant (post-test)
+        if: always() && github.ref == 'refs/heads/main'
         env:
           PORTH_TENANTS_TABLE: ${{ env.PORTH_TENANTS_TABLE }}
           PORTH_PERMISSIONS_TABLE: ${{ env.PORTH_PERMISSIONS_TABLE }}
@@ -263,6 +266,7 @@ jobs:
       # Audience is read from PORTH_TENANT_CONFIG (same JSON blob used for E2E IdP
       # setup). PLATFORM_AUTH0_AUDIENCE is used as fallback if not present.
       - name: Patch platform tenant IdP config
+        if: always() && github.ref == 'refs/heads/main'
         env:
           PORTH_TENANT_CONFIG: ${{ secrets.PORTH_TENANT_CONFIG }}
         run: |

--- a/scripts/api-tests/00-setup.sh
+++ b/scripts/api-tests/00-setup.sh
@@ -22,7 +22,8 @@ ORG_PAYLOAD=$(cat <<EOF
   "tenant": {
     "tenant_id": "$TENANT_ID",
     "display_name": "Smoke Test Tenant",
-    "environment_type": "development"
+    "environment_type": "development",
+    "admin_role_source_key": "tenant-admin"
   }
 }
 EOF

--- a/scripts/api-tests/10-neg-organizations.sh
+++ b/scripts/api-tests/10-neg-organizations.sh
@@ -25,7 +25,7 @@ STATUS=$(api_request "POST" "/organizations" "$RESPONSE_FILE" "$PAYLOAD" | tail 
 if [[ "$STATUS" == "400" || "$STATUS" == "422" ]]; then pass "NEG-O03: missing tenant (HTTP $STATUS)"
 else fail "NEG-O03: missing tenant (expected 400/422, got $STATUS)"; fi
 
-PAYLOAD='{"name": "Dup Slug Org", "slug": "test-org-smoke", "tenant": {"tenant_id": "t-neg-o04", "display_name": "Dup", "environment_type": "development"}}'
+PAYLOAD='{"name": "Dup Slug Org", "slug": "test-org-smoke", "tenant": {"tenant_id": "t-neg-o04", "display_name": "Dup", "environment_type": "development", "admin_role_source_key": "tenant-admin"}}'
 STATUS=$(api_request "POST" "/organizations" "$RESPONSE_FILE" "$PAYLOAD" | tail -1)
 if [[ "$STATUS" == "409" || "$STATUS" == "400" ]]; then pass "NEG-O04: duplicate slug (HTTP $STATUS)"
 else fail "NEG-O04: duplicate slug (expected 409/400, got $STATUS)"; fi

--- a/scripts/api-tests/11-neg-tenants.sh
+++ b/scripts/api-tests/11-neg-tenants.sh
@@ -12,14 +12,14 @@ RESPONSE_FILE="/tmp/porth-neg-tenants.json"
 TENANT_ID="t-test-1"
 ORG_ID=$(python3 -c "import json; data = json.load(open('/tmp/porth-test-setup-ids.json')); print(data.get('org_id', ''))" 2>/dev/null || echo "")
 
-STATUS=$(api_request "PUT" "/tenants" "$RESPONSE_FILE" '{"org_id": "nonexistent-org-xyz", "tenant_id": "t-neg-t01", "display_name": "Neg Test", "environment_type": "development"}' | tail -1)
+STATUS=$(api_request "PUT" "/tenants" "$RESPONSE_FILE" '{"org_id": "nonexistent-org-xyz", "tenant_id": "t-neg-t01", "display_name": "Neg Test", "environment_type": "development", "admin_role_source_key": "tenant-admin"}' | tail -1)
 if [[ "$STATUS" == "404" ]]; then pass "NEG-T01: PUT nonexistent org_id (HTTP 404)"
 else fail "NEG-T01: PUT nonexistent org_id (expected 404, got $STATUS)"; fi
 
 echo "NEG-T02: PUT duplicate tenant_id '$TENANT_ID'"
 if [[ -n "$ORG_ID" ]]; then
     PAYLOAD=$(cat <<EOF
-{"org_id": "$ORG_ID", "tenant_id": "$TENANT_ID", "display_name": "Duplicate", "environment_type": "development"}
+{"org_id": "$ORG_ID", "tenant_id": "$TENANT_ID", "display_name": "Duplicate", "environment_type": "development", "admin_role_source_key": "tenant-admin"}
 EOF
 )
     STATUS=$(api_request "PUT" "/tenants" "$RESPONSE_FILE" "$PAYLOAD" | tail -1)


### PR DESCRIPTION
Jira: [PORTH-444](https://estynsoftware.atlassian.net/browse/PORTH-444)
Closes #33

## Summary

After deploying components PRs #125 (`77c1bd5`) and #126 (`a84a840`, PORTH-443 foundation), `Deploy Admin UI` #186 failed at the E2E step and left all six `porth-*-dev` DynamoDB tables empty. Two distinct bugs, fixed together:

- **`deploy.yml` — empty DB on E2E failure.** The post-test `Cleanup` step runs `if: always()`, but `Bootstrap platform tenant (post-test)` and `Patch platform tenant IdP config` had no `if:` guard. A failed E2E step wiped the tables but skipped the re-seed. Both steps now carry `if: always() && github.ref == 'refs/heads/main'`, matching the cleanup step — so wipe + re-seed are atomic.
- **api-tests broken by PORTH-443.** PR #126 made `admin_role_source_key` a required field on `TenantCreate` / `TenantAddToOrg`. `00-setup.sh`, `10-neg-organizations.sh`, and `11-neg-tenants.sh` POST organizations/tenants without it → `422`, failing the positive setup and cascading. Added `admin_role_source_key` to those payloads. Pure "missing field" negative tests are unchanged — they correctly expect `422`.

## Why both in one PR

`deploy.yml`'s bootstrap script writes straight to DynamoDB, so fix 1 alone re-seeds the DB on the next deploy; fix 2 is needed for the deploy job to go fully green. Both are required for "redeploy the sample app → DynamoDB seeded and green" to hold.

## Test plan

- [ ] CI green on this branch
- [ ] After merge to `main`: `Deploy Admin UI` re-seeds the platform tenant (DynamoDB non-empty) even though E2E may still surface issues, and — with the api-test payload fixes — the E2E step itself passes, leaving the run green

## Out of scope

- The components-side concurrency guard for components `deploy.yml` (separate components PR)
- The estyn-api MCP transport / `/whoami` 500 issues
- Creating the `/porth/dev/tenant-admin-*` SSM parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)