### PR TITLE
[PORTH-448] Make DynamoDB wipe opt-in in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -258,8 +258,10 @@ jobs:
           EOF
 
       # ── Step 7: Bootstrap platform tenant ───────────────────────────────────────
-      # Runs on every main deploy (idempotent — safe to run against live data).
-      # also serves as the post-test reseed when run_api_tests is true, so always()
+      # Runs on every main deploy. Applies platform configuration changes
+      # (permissions upserted, role-permission links regenerated, claim mapping
+      # versioned) while leaving user-created tenants, orgs and users untouched.
+      # Also serves as the post-test reseed when run_api_tests is true, so always()
       # is required to ensure it runs even if the integration tests or cleanup failed.
       - name: Bootstrap platform tenant
         if: always() && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: ['**']
   workflow_dispatch:
+    inputs:
+      run_api_tests:
+        description: 'Run API integration tests (wipes all DynamoDB tables before and after — opt-in only)'
+        type: boolean
+        default: false
 
 # Serialise deploy runs per branch — prevents concurrent cleanup/bootstrap
 # steps from racing each other and deleting the platform tenant mid-flight.
@@ -164,8 +169,10 @@ jobs:
             --paths "/*"
 
       # ── Step 3: Cleanup (pre-test) ─────────────────────────────────────────────
+      # Only runs when explicitly opted in via workflow_dispatch run_api_tests:true.
+      # Normal pushes to main never wipe DynamoDB — use reset-env.yml for that.
       - name: Cleanup (pre-test)
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
         run: |
           python3 - <<'EOF'
           import boto3, json, sys
@@ -199,7 +206,7 @@ jobs:
 
       # ── Step 4: Bootstrap platform tenant (pre-test) ────────────────────────────
       - name: Bootstrap platform tenant (pre-test)
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
         env:
           PORTH_TENANTS_TABLE: ${{ env.PORTH_TENANTS_TABLE }}
           PORTH_PERMISSIONS_TABLE: ${{ env.PORTH_PERMISSIONS_TABLE }}
@@ -207,9 +214,9 @@ jobs:
           PORTH_CLAIM_MAPPING_CONFIGS_TABLE: ${{ env.PORTH_CLAIM_MAPPING_CONFIGS_TABLE }}
         run: python3 scripts/bootstrap_platform_tenant.py
 
-      # ── Step 5: Run E2E tests ───────────────────────────────────────────────────
-      - name: Run E2E tests
-        if: github.ref == 'refs/heads/main'
+      # ── Step 5: Run API integration tests ──────────────────────────────────────
+      - name: Run API integration tests
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
         env:
           PORTH_AUTH_TEST_TOKEN: ${{ secrets.PORTH_AUTH_TEST_TOKEN }}
         run: |
@@ -218,7 +225,7 @@ jobs:
 
       # ── Step 6: Cleanup (post-test) ──────────────────────────────────────────────
       - name: Cleanup (post-test)
-        if: always() && github.ref == 'refs/heads/main'
+        if: always() && github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
         run: |
           python3 - <<'EOF'
           import boto3, json, sys
@@ -250,10 +257,11 @@ jobs:
           sys.exit(1 if failed else 0)
           EOF
 
-      # ── Step 7: Bootstrap platform tenant (post-test) ────────────────────────────
-      # always() — a failed E2E step above must still re-seed the tables that the
-      # post-test cleanup (also always()) just wiped, or DynamoDB is left empty.
-      - name: Bootstrap platform tenant (post-test)
+      # ── Step 7: Bootstrap platform tenant ───────────────────────────────────────
+      # Runs on every main deploy (idempotent — safe to run against live data).
+      # also serves as the post-test reseed when run_api_tests is true, so always()
+      # is required to ensure it runs even if the integration tests or cleanup failed.
+      - name: Bootstrap platform tenant
         if: always() && github.ref == 'refs/heads/main'
         env:
           PORTH_TENANTS_TABLE: ${{ env.PORTH_TENANTS_TABLE }}


### PR DESCRIPTION
## Summary
- Adds `run_api_tests: boolean` (default: `false`) to `workflow_dispatch` inputs
- Gates the four destructive steps (wipe pre-test, bootstrap pre-test, API integration tests, wipe post-test) behind `inputs.run_api_tests == true` — they **never** run on automated pushes
- Idempotent bootstrap (step 7) and IdP config patch (step 8) continue running unconditionally on every `main` deploy
- Renames "Bootstrap platform tenant (post-test)" → "Bootstrap platform tenant" since it now serves as the sole bootstrap on normal deploys

Closes #35 | PORTH-448

## Behaviour after this PR

| Trigger | DynamoDB | What runs |
|---|---|---|
| Push to `main` | **Untouched** | deploy + bootstrap (idempotent) + patch IdP |
| Push to feature branch | Untouched | deploy only |
| `workflow_dispatch` (default) | Untouched | deploy + bootstrap + patch IdP |
| `workflow_dispatch` + `run_api_tests: true` | Wipe → reseed | full: deploy + wipe + bootstrap + API tests + wipe + bootstrap + patch IdP |

For an explicit nuke-and-reseed without a code deploy, `reset-env.yml` remains available.

## Test plan
- [ ] Verify the deploy runs cleanly on a push to `main` (CI should pass without hitting any DynamoDB steps)
- [ ] Manually trigger `Deploy Admin UI` with `run_api_tests: true` and confirm the API test cycle runs (wipe → bootstrap → tests → wipe → bootstrap)
- [ ] Confirm `reset-env.yml` still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)