### PR TITLE
ci(porth): A-01 SAR POC install + verify workflow (PORTH-459)

### DIFF
--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -1,0 +1,110 @@
+name: Porth SAR POC — install + verify
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'SAR app semantic version to install'
+        required: true
+        default: '0.0.0-poc'
+      stack_name:
+        description: 'CFN stack name'
+        required: true
+        default: 'porth-sar-poc'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  install-and-verify:
+    runs-on: ubuntu-latest
+    environment: porth-install
+    env:
+      STACK: ${{ inputs.stack_name }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Find published SAR app
+        id: find-app
+        run: |
+          set -euo pipefail
+          APP_ARN=$(aws serverlessrepo list-applications \
+            --query "Applications[?Name=='porth-user-management'].ApplicationId | [0]" \
+            --output text)
+          if [ -z "$APP_ARN" ] || [ "$APP_ARN" = "None" ]; then
+            echo "ERROR: porth-user-management not visible from EMS account — check org-share policy on the publish side."
+            exit 1
+          fi
+          echo "app_arn=$APP_ARN" >> "$GITHUB_OUTPUT"
+          echo "Found SAR app: $APP_ARN"
+
+      - name: Create change set
+        id: change-set
+        run: |
+          set -euo pipefail
+          CHANGE_SET=$(aws serverlessrepo create-cloud-formation-change-set \
+            --application-id "${{ steps.find-app.outputs.app_arn }}" \
+            --semantic-version "${{ inputs.version }}" \
+            --stack-name "$STACK" \
+            --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
+            --parameter-overrides 'Name=Environment,Value=ems-verify' \
+            --query 'ChangeSetId' --output text)
+          echo "change_set=$CHANGE_SET" >> "$GITHUB_OUTPUT"
+          aws cloudformation wait change-set-create-complete --change-set-name "$CHANGE_SET"
+
+      - name: Execute change set
+        run: |
+          set -euo pipefail
+          aws cloudformation execute-change-set --change-set-name "${{ steps.change-set.outputs.change_set }}"
+          # serverlessrepo prefixes the actual stack name with `serverlessrepo-`
+          aws cloudformation wait stack-create-complete --stack-name "serverlessrepo-${STACK}"
+
+      - name: Smoke test — Lambda URL + DDB
+        id: smoke
+        run: |
+          set -euo pipefail
+          URL=$(aws cloudformation describe-stacks --stack-name "serverlessrepo-${STACK}" \
+            --query "Stacks[0].Outputs[?OutputKey=='HelloWorldFnUrl'].OutputValue" --output text)
+          echo "Lambda URL: $URL"
+          curl -fsSL "$URL" | tee response.json
+          grep -q '"message": "porth SAR POC alive"' response.json
+          TABLE=$(aws cloudformation describe-stacks --stack-name "serverlessrepo-${STACK}" \
+            --query "Stacks[0].Outputs[?OutputKey=='HelloWorldTableName'].OutputValue" --output text)
+          echo "DDB table: $TABLE"
+          aws dynamodb describe-table --table-name "$TABLE" >/dev/null
+          {
+            echo "## Porth SAR POC install — smoke test PASS"
+            echo "- **Stack:** \`serverlessrepo-${STACK}\`"
+            echo "- **Lambda URL:** $URL"
+            echo "- **DDB table:** \`$TABLE\`"
+            echo ""
+            echo "### Response body"
+            echo '```json'
+            cat response.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Teardown — stack
+        if: always()
+        run: |
+          set -euo pipefail
+          aws cloudformation delete-stack --stack-name "serverlessrepo-${STACK}" || true
+          aws cloudformation wait stack-delete-complete --stack-name "serverlessrepo-${STACK}" || true
+
+      - name: Teardown — orphaned Retain DDB table (POC only)
+        if: always()
+        # DDB is `Retain` per ADR-Z2. For real Porth installs we *want* this.
+        # For the POC tracer we don't, so explicitly delete it after stack tear-down.
+        run: |
+          set -euo pipefail
+          TABLE_NAME="porth-ems-verify-hello-world"
+          if aws dynamodb describe-table --table-name "$TABLE_NAME" >/dev/null 2>&1; then
+            echo "Deleting retained POC table: $TABLE_NAME"
+            aws dynamodb delete-table --table-name "$TABLE_NAME"
+          else
+            echo "POC table $TABLE_NAME not present — nothing to clean up."
+          fi

--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -8,9 +8,9 @@ on:
         required: true
         default: '0.0.0-poc'
       stack_name:
-        description: 'CFN stack name'
+        description: 'CFN stack name (must match ^serverlessrepo-porth-sar-[a-zA-Z0-9-]+$)'
         required: true
-        default: 'porth-sar-poc'
+        default: 'serverlessrepo-porth-sar-poc'
 
 permissions:
   id-token: write
@@ -23,20 +23,72 @@ jobs:
     env:
       STACK: ${{ inputs.stack_name }}
     steps:
+      - name: Validate inputs
+        # MF9 (security HIGH): reject any operator-supplied stack_name that
+        # doesn't match the expected prefix pattern, before it can flow into
+        # describe-stacks / delete-stack / wait calls below.
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          STACK_INPUT="${{ inputs.stack_name }}"
+          if [[ ! "$STACK_INPUT" =~ ^serverlessrepo-porth-sar-[a-zA-Z0-9-]+$ ]]; then
+            echo "::error::Invalid stack_name input: $STACK_INPUT — must match ^serverlessrepo-porth-sar-[a-zA-Z0-9-]+$"
+            exit 1
+          fi
+
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Pre-flight stack-state recovery
+        # MF7: ported from X-01's porth-pr-stack-provision.yml settle-wait pattern
+        # plus the X-01.1 follow-up — delete-and-recreate on recoverable-failure
+        # states instead of waiting indefinitely.
+        # Emits stack_action=CREATE or stack_action=UPDATE for MF8 (waiter selection).
+        id: preflight
+        run: |
+          set -euo pipefail
+          STATUS=$(aws cloudformation describe-stacks \
+            --stack-name "$STACK" \
+            --region "${{ vars.AWS_REGION }}" \
+            --query "Stacks[0].StackStatus" \
+            --output text 2>/dev/null || echo "DOES_NOT_EXIST")
+          echo "Pre-flight stack status: $STATUS"
+          case "$STATUS" in
+            DOES_NOT_EXIST)
+              echo "Stack does not exist — change-set execute will CREATE."
+              echo "stack_action=CREATE" >> "$GITHUB_OUTPUT"
+              ;;
+            CREATE_COMPLETE|UPDATE_COMPLETE|UPDATE_ROLLBACK_COMPLETE)
+              echo "Stack in clean state ($STATUS) — change-set execute will UPDATE."
+              echo "stack_action=UPDATE" >> "$GITHUB_OUTPUT"
+              ;;
+            REVIEW_IN_PROGRESS|ROLLBACK_COMPLETE|CREATE_FAILED|DELETE_FAILED)
+              echo "::warning::Stack in recoverable-failure state ($STATUS) — deleting and recreating"
+              aws cloudformation delete-stack --stack-name "$STACK" --region "${{ vars.AWS_REGION }}"
+              aws cloudformation wait stack-delete-complete --stack-name "$STACK" --region "${{ vars.AWS_REGION }}"
+              echo "stack_action=CREATE" >> "$GITHUB_OUTPUT"
+              ;;
+            *_IN_PROGRESS)
+              echo "::error::Stack in non-terminal state ($STATUS) — investigate manually before re-running"
+              exit 1
+              ;;
+            *)
+              echo "::error::Stack in unexpected state ($STATUS)"
+              exit 1
+              ;;
+          esac
 
       - name: Find published SAR app
         id: find-app
         run: |
           set -euo pipefail
           APP_ARN=$(aws serverlessrepo list-applications \
-            --query "Applications[?Name=='porth-user-management'].ApplicationId | [0]" \
+            --query "Applications[?Name=='porth-user-management-poc'].ApplicationId | [0]" \
             --output text)
           if [ -z "$APP_ARN" ] || [ "$APP_ARN" = "None" ]; then
-            echo "ERROR: porth-user-management not visible from EMS account — check org-share policy on the publish side."
+            echo "ERROR: porth-user-management-poc not visible from EMS account — check org-share policy on the publish side."
             exit 1
           fi
           echo "app_arn=$APP_ARN" >> "$GITHUB_OUTPUT"
@@ -46,10 +98,15 @@ jobs:
         id: change-set
         run: |
           set -euo pipefail
+          # serverlessrepo create-cloud-formation-change-set takes the
+          # *unprefixed* stack name; SAR adds the `serverlessrepo-` prefix
+          # itself. Operator-supplied STACK is the full prefixed name, so
+          # strip the prefix for the SAR call.
+          SAR_STACK_NAME="${STACK#serverlessrepo-}"
           CHANGE_SET=$(aws serverlessrepo create-cloud-formation-change-set \
             --application-id "${{ steps.find-app.outputs.app_arn }}" \
             --semantic-version "${{ inputs.version }}" \
-            --stack-name "$STACK" \
+            --stack-name "$SAR_STACK_NAME" \
             --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
             --parameter-overrides 'Name=Environment,Value=ems-verify' \
             --query 'ChangeSetId' --output text)
@@ -57,28 +114,35 @@ jobs:
           aws cloudformation wait change-set-create-complete --change-set-name "$CHANGE_SET"
 
       - name: Execute change set
+        # MF8: select the right terminal-state waiter based on the pre-flight
+        # action. `wait stack-create-complete` hangs forever on UPDATE re-runs
+        # because UPDATE never reaches CREATE_COMPLETE.
         run: |
           set -euo pipefail
           aws cloudformation execute-change-set --change-set-name "${{ steps.change-set.outputs.change_set }}"
-          # serverlessrepo prefixes the actual stack name with `serverlessrepo-`
-          aws cloudformation wait stack-create-complete --stack-name "serverlessrepo-${STACK}"
+          ACTION="${{ steps.preflight.outputs.stack_action }}"
+          if [ "$ACTION" = "CREATE" ]; then
+            aws cloudformation wait stack-create-complete --stack-name "$STACK"
+          else
+            aws cloudformation wait stack-update-complete --stack-name "$STACK"
+          fi
 
       - name: Smoke test — Lambda URL + DDB
         id: smoke
         run: |
           set -euo pipefail
-          URL=$(aws cloudformation describe-stacks --stack-name "serverlessrepo-${STACK}" \
+          URL=$(aws cloudformation describe-stacks --stack-name "$STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='HelloWorldFnUrl'].OutputValue" --output text)
           echo "Lambda URL: $URL"
           curl -fsSL "$URL" | tee response.json
           grep -q '"message": "porth SAR POC alive"' response.json
-          TABLE=$(aws cloudformation describe-stacks --stack-name "serverlessrepo-${STACK}" \
+          TABLE=$(aws cloudformation describe-stacks --stack-name "$STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='HelloWorldTableName'].OutputValue" --output text)
           echo "DDB table: $TABLE"
           aws dynamodb describe-table --table-name "$TABLE" >/dev/null
           {
             echo "## Porth SAR POC install — smoke test PASS"
-            echo "- **Stack:** \`serverlessrepo-${STACK}\`"
+            echo "- **Stack:** \`$STACK\`"
             echo "- **Lambda URL:** $URL"
             echo "- **DDB table:** \`$TABLE\`"
             echo ""
@@ -92,8 +156,8 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          aws cloudformation delete-stack --stack-name "serverlessrepo-${STACK}" || true
-          aws cloudformation wait stack-delete-complete --stack-name "serverlessrepo-${STACK}" || true
+          aws cloudformation delete-stack --stack-name "$STACK" || true
+          aws cloudformation wait stack-delete-complete --stack-name "$STACK" || true
 
       - name: Teardown — orphaned Retain DDB table (POC only)
         if: always()


### PR DESCRIPTION
## Summary

[PORTH-459](https://estynsoftware.atlassian.net/browse/PORTH-459) — companion to the `dragoninex1le/components` PR (`porth-459-sar-poc-publish`).

Adds a `workflow_dispatch`-triggered workflow that:

1. Assumes `porth-install-role` in the EMS account (`195950944420`) via the `porth-install` GitHub environment.
2. Discovers the org-shared `porth-user-management` SAR app (cross-account org-share evidence).
3. Creates + executes a CloudFormation change set to install version `0.0.0-poc` as stack `serverlessrepo-porth-sar-poc`.
4. Smoke-tests the placeholder Lambda Function URL + `describe-table`s the DDB table.
5. Tears down the stack + explicitly deletes the retained DDB POC table.

## Files

| Path | Purpose |
| --- | --- |
| `.github/workflows/porth-sar-poc-install.yml` | The install + verify + teardown workflow. |

## Implementation notes — PORTH-461 / X-01 learnings applied

- Workflow assumes `${{ vars.AWS_ROLE_ARN }}` from the `porth-install` GitHub environment — **verify the env var matches the actual IAM role name** (X-01 hit a documented-vs-actual naming mismatch). Expected actual: `porth-install-role`.
- The `porth-cfn-execution-role` (used implicitly by serverlessrepo via the install role's PassRole) needs the `SAMTransformMacro` Sid — `cloudformation:CreateChangeSet` on `arn:aws:cloudformation:us-east-1:aws:transform/Serverless-2016-10-31`. **If install fails with `Transform … is not authorized` re-check the inline policy.**
- `CAPABILITY_AUTO_EXPAND` included alongside `CAPABILITY_IAM` because the SAM transform expands at change-set time.
- Stack name is prefixed with `serverlessrepo-` automatically by `create-cloud-formation-change-set` — `describe-stacks` / `delete-stack` use that prefix.
- POC DDB cleanup is explicit because ADR-Z2 mandates `Retain`. Real Porth installs will keep tables — this cleanup is POC-only.

## How it links

- **Publish side:** `dragoninex1le/components` companion PR adds the SAM template + publish workflow on branch `porth-459-sar-poc-publish`. This PR depends on **that PR being merged and the publish workflow having run successfully at least once** before this workflow can pass when triggered.

## Acceptance criteria coverage

| AC | Covered by |
| --- | --- |
| EMS account sees the app | `Find published SAR app` step (fails fast with helpful message if org-share is wrong) |
| Install via change set + execute succeeds | `Create change set` + `Execute change set` |
| Lambda URL returns 200 with expected body | `Smoke test` step — `curl -fsSL` + `grep` |
| DDB table exists in EMS, not components | `aws dynamodb describe-table` in smoke test |
| Teardown clean | `Teardown — stack` + `Teardown — orphaned Retain DDB table` |

## Reviewers

- Chris (Engineering Head) — architecture + release readiness
- James (Solutions Architect) — ADR-Z1/Z2/Z3 alignment

## Review panel

Copilot review is replaced by a 3-agent review panel (Steve / Chris / Head of Security) — comments will appear shortly after this PR opens.

## References

- [PORTH-459](https://estynsoftware.atlassian.net/browse/PORTH-459)
- [PORTH-266](https://estynsoftware.atlassian.net/browse/PORTH-266)
- [PORTH-461](https://estynsoftware.atlassian.net/browse/PORTH-461) (IAM bootstrap)
- ADR-Z1, ADR-Z2, ADR-Z3, ADR-Z5
