### PR TITLE
fix(porth-459): use SAR app ARN directly instead of broken list-applications lookup

### DIFF
--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -11,6 +11,10 @@ on:
         description: 'CFN stack name (must match ^serverlessrepo-porth-sar-[a-zA-Z0-9-]+$)'
         required: true
         default: 'serverlessrepo-porth-sar-poc'
+      application_arn:
+        description: 'SAR app ARN (out-of-band from publisher). Cross-account-shared SAR apps cannot be discovered via list-applications — that API only returns apps owned by the calling account.'
+        required: true
+        default: 'arn:aws:serverlessrepo:us-east-1:084847995635:applications/porth-user-management-poc'
 
 permissions:
   id-token: write
@@ -33,6 +37,11 @@ jobs:
           STACK_INPUT="${{ inputs.stack_name }}"
           if [[ ! "$STACK_INPUT" =~ ^serverlessrepo-porth-sar-[a-zA-Z0-9-]+$ ]]; then
             echo "::error::Invalid stack_name input: $STACK_INPUT — must match ^serverlessrepo-porth-sar-[a-zA-Z0-9-]+$"
+            exit 1
+          fi
+          APP_ARN_INPUT="${{ inputs.application_arn }}"
+          if [[ ! "$APP_ARN_INPUT" =~ ^arn:aws:serverlessrepo:[a-z0-9-]+:[0-9]+:applications/[a-zA-Z0-9_-]+$ ]]; then
+            echo "::error::Invalid application_arn input: $APP_ARN_INPUT — must be a SAR application ARN"
             exit 1
           fi
 
@@ -80,22 +89,13 @@ jobs:
               ;;
           esac
 
-      - name: Find published SAR app
-        id: find-app
-        run: |
-          set -euo pipefail
-          APP_ARN=$(aws serverlessrepo list-applications \
-            --query "Applications[?Name=='porth-user-management-poc'].ApplicationId | [0]" \
-            --output text)
-          if [ -z "$APP_ARN" ] || [ "$APP_ARN" = "None" ]; then
-            echo "ERROR: porth-user-management-poc not visible from EMS account — check org-share policy on the publish side."
-            exit 1
-          fi
-          echo "app_arn=$APP_ARN" >> "$GITHUB_OUTPUT"
-          echo "Found SAR app: $APP_ARN"
-
       - name: Create change set
         id: change-set
+        # Use the operator-supplied SAR app ARN directly. Org-shared SAR apps
+        # cannot be discovered via list-applications (that only returns apps
+        # owned by the caller). The publisher must communicate the ARN out-of-band
+        # (release notes, doc, etc.); for real Porth installs the ARN goes into
+        # the receiving product's release-config.
         run: |
           set -euo pipefail
           # serverlessrepo create-cloud-formation-change-set takes the
@@ -104,7 +104,7 @@ jobs:
           # strip the prefix for the SAR call.
           SAR_STACK_NAME="${STACK#serverlessrepo-}"
           CHANGE_SET=$(aws serverlessrepo create-cloud-formation-change-set \
-            --application-id "${{ steps.find-app.outputs.app_arn }}" \
+            --application-id "${{ inputs.application_arn }}" \
             --semantic-version "${{ inputs.version }}" \
             --stack-name "$SAR_STACK_NAME" \
             --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \


### PR DESCRIPTION
## What

Replaces the "Find published SAR app" step's `list-applications` lookup with a direct workflow_dispatch input (`application_arn`) for the SAR app ARN.

## Why

`serverlessrepo:list-applications` only returns apps OWNED BY the calling account. Org-shared apps from other accounts **do not appear** in that list. There is no `list-shared-applications` equivalent in AWS — consumers are expected to have the App ARN out-of-band.

Discovered during PORTH-459 install smoke test ([run 26004515896](https://github.com/dragoninex1le/enterprise-membership-sample/actions/runs/26004515896)) after deltas #11/#12/#13 on PORTH-461 (IAM) all landed green but the workflow still failed with:

```
ERROR: porth-user-management-poc not visible from EMS account
```

## The change

- Added `application_arn` workflow_dispatch input with default `arn:aws:serverlessrepo:us-east-1:084847995635:applications/porth-user-management-poc` (the actual published ARN from the green publish run)
- Added input regex validation (rejects malformed ARNs before they reach AWS API)
- Removed the broken "Find published SAR app" step
- "Create change set" step now uses `${{ inputs.application_arn }}` directly

## Pattern note for real Porth distribution

When real Porth content lands in A-02, the receiving product team's release-config repo will record the SAR app ARN as part of their pinned dependency manifest. The publish-side release process must include the ARN in release notes / docs so consumers can pin it.

## Test plan

- [ ] Merge this PR (squash)
- [ ] Orchestrator re-dispatches the install workflow
- [ ] All steps green, smoke test passes against the Lambda URL
- [ ] Stack + retained DDB table cleanly torn down at job end

## Why no panel

Same as #147 — workflow-design fix discovered during tracer smoke test, well-bounded, won't ship anywhere real Porth content lives. Richard's "yes go ahead" on #147 pattern is the precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
