### PR TITLE
PORTH-459: add SAR diagnostic steps before create-change-set (debug-only)

### DIFF
--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -50,6 +50,48 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      - name: Diagnostic — caller identity (PORTH-459 SAR debug)
+        # Confirms which account context this job is actually running under.
+        run: |
+          set -euo pipefail
+          aws sts get-caller-identity
+
+      - name: Diagnostic — SAR get-application (PORTH-459 SAR debug)
+        # Confirms the SAR app is visible to this consumer account and exposes
+        # the TemplateUrl that SAR has cached. If this fails with AccessDenied,
+        # the issue is at the SAR application-policy level, not S3.
+        id: sar-diag
+        run: |
+          set -euo pipefail
+          echo "Calling serverlessrepo get-application..."
+          GET_OUT=$(aws serverlessrepo get-application \
+            --application-id "${{ inputs.application_arn }}" \
+            --semantic-version "${{ inputs.version }}" \
+            --output json) || { echo "::error::get-application FAILED"; exit 1; }
+          echo "$GET_OUT" | jq '.'
+          TEMPLATE_URL=$(echo "$GET_OUT" | jq -r '.Version.TemplateUrl // empty')
+          echo "TemplateUrl: $TEMPLATE_URL"
+          echo "template_url=$TEMPLATE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Diagnostic — probe TemplateUrl (PORTH-459 SAR debug)
+        # If the TemplateUrl is an S3 URL, try to HEAD it. If it's an HTTPS
+        # presigned URL, curl it. Whatever comes back will tell us whether
+        # the URL is reachable from the consumer role context.
+        if: steps.sar-diag.outputs.template_url != ''
+        run: |
+          set -euo pipefail
+          URL="${{ steps.sar-diag.outputs.template_url }}"
+          echo "Probing: $URL"
+          if [[ "$URL" =~ ^s3:// ]]; then
+            BUCKET=$(echo "$URL" | sed -E 's|^s3://([^/]+)/.*|\1|')
+            KEY=$(echo "$URL" | sed -E 's|^s3://[^/]+/(.+)|\1|')
+            echo "S3 URL: bucket=$BUCKET key=$KEY"
+            aws s3api head-object --bucket "$BUCKET" --key "$KEY" || echo "::warning::head-object failed"
+          elif [[ "$URL" =~ ^https?:// ]]; then
+            echo "HTTPS URL — trying curl HEAD"
+            curl -sIv -o /dev/null "$URL" 2>&1 | head -20 || true
+          fi
+
       - name: Pre-flight stack-state recovery
         # MF7: ported from X-01's porth-pr-stack-provision.yml settle-wait pattern
         # plus the X-01.1 follow-up — delete-and-recreate on recoverable-failure


### PR DESCRIPTION
## Why

5 consecutive failures of `serverlessrepo create-cloud-formation-change-set` with `S3 error: Access Denied`, even after IAM fixes on all 3 surfaces (bucket policy actions/principal + consumer identity policy) and a full SAR republish at a new semver. We've ruled out the IAM and SAR-cache hypotheses. Need to instrument the workflow to see what SAR is actually returning before the create-change-set call so we can narrow the root cause definitively.

## Change

Adds three diagnostic steps between `configure-aws-credentials` and the existing `Pre-flight stack-state recovery`:

1. **`aws sts get-caller-identity`** — sanity check on the role assumed
2. **`aws serverlessrepo get-application`** — proves whether the SAR app is visible from EMS and exposes the `TemplateUrl` SAR has cached
3. **TemplateUrl probe** — `aws s3api head-object` if it's an S3 URL, `curl -sIv` if it's HTTPS — proves whether the URL is reachable from the consumer role

No production behavior change; if all three pass and create-change-set still fails, we know the issue is between SAR and CFN's template validation (not at the SAR API surface).

## Test plan

1. Merge this PR.
2. Re-dispatch `porth-sar-poc-install.yml` with `version=0.0.0-poc.1`.
3. Read diagnostic output:
   - get-application succeeds → app is visible, share is working → look deeper into CFN's validation
   - get-application AccessDenied → SAR application-policy hasn't propagated; need to add EMS account ARN explicitly
   - get-application succeeds but TemplateUrl probe AccessDenied → template lives in a bucket we haven't granted access to; fix that bucket policy
4. After we have the data, follow-up PR to either revert these steps or keep them as defence-in-depth.

## POC waiver

Diagnostic-only PR for active triage on PORTH-459. Smoke-test workflow only — no production exposure. Same waiver request pattern as PRs Components #144 / #146 / #148.