### PR TITLE
PORTH-459: capture change-set StatusReason on waiter failure

### DIFF
--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -138,6 +138,10 @@ jobs:
         # owned by the caller). The publisher must communicate the ARN out-of-band
         # (release notes, doc, etc.); for real Porth installs the ARN goes into
         # the receiving product's release-config.
+        # PORTH-459 hardening: if the waiter exits non-zero, immediately
+        # describe-change-set and print Status+StatusReason+ExecutionStatus
+        # before propagating the failure. Without this, the always-on teardown
+        # step deletes the stack and takes the change-set evidence with it.
         run: |
           set -euo pipefail
           # serverlessrepo create-cloud-formation-change-set takes the
@@ -153,7 +157,24 @@ jobs:
             --parameter-overrides 'Name=Environment,Value=ems-verify' \
             --query 'ChangeSetId' --output text)
           echo "change_set=$CHANGE_SET" >> "$GITHUB_OUTPUT"
+          echo "Created change set: $CHANGE_SET"
+
+          # Wait, but capture exit code so we can diagnose on failure.
+          set +e
           aws cloudformation wait change-set-create-complete --change-set-name "$CHANGE_SET"
+          WAIT_RC=$?
+          set -e
+
+          if [ "$WAIT_RC" -ne 0 ]; then
+            echo "::warning::Waiter failed (rc=$WAIT_RC) — capturing change-set details before teardown"
+            echo "----- describe-change-set output -----"
+            aws cloudformation describe-change-set \
+              --change-set-name "$CHANGE_SET" \
+              --query '{Status:Status,StatusReason:StatusReason,ExecutionStatus:ExecutionStatus}' \
+              --output json || echo "describe-change-set itself failed"
+            echo "----- end describe-change-set -----"
+            exit "$WAIT_RC"
+          fi
 
       - name: Execute change set
         # MF8: select the right terminal-state waiter based on the pre-flight


### PR DESCRIPTION
## Why

After delta #19 the EMS install workflow now gets past the immediate `S3 error: Access Denied` and the change set is successfully created. But the waiter then sees `Status: FAILED` on the change set itself with no further detail in workflow logs. The always-on teardown step then deletes the failed stack, so the StatusReason can't be retrieved from Console afterward (confirmed by Richard — no stacks in EMS CF console).

## Change

Restructure the Create change set step to:
1. Run the waiter with `set +e` so we capture exit code
2. On failure, immediately `aws cloudformation describe-change-set --query '{Status,StatusReason,ExecutionStatus}'` and print the result
3. Propagate the non-zero exit so the workflow still fails

Net additional bytes ≈ 15 lines. Behavior unchanged on success. Good defence-in-depth for production too — operators re-running in a year want StatusReason in their logs.

## Test plan

1. Merge.
2. Re-dispatch install workflow with version 0.0.0-poc.1.
3. Read StatusReason from workflow logs.
4. Apply the next fix based on what it says.

## POC waiver

Diagnostic-grade change for active triage on PORTH-459. Same waiver request pattern as PRs #144 / #146 / #148 / #39.