### PR TITLE
PORTH-459: capture stack events on Execute change set failure

### DIFF
--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -180,14 +180,34 @@ jobs:
         # MF8: select the right terminal-state waiter based on the pre-flight
         # action. `wait stack-create-complete` hangs forever on UPDATE re-runs
         # because UPDATE never reaches CREATE_COMPLETE.
+        # PORTH-459 hardening: same waiter+diagnose pattern as Create change set.
+        # On waiter failure, print the most-recent FAILED stack events
+        # (LogicalResourceId, ResourceStatus, ResourceStatusReason) before the
+        # always-on teardown wipes them. Without this we just see a generic
+        # "ROLLBACK_COMPLETE" with no clue which resource failed or why.
         run: |
           set -euo pipefail
           aws cloudformation execute-change-set --change-set-name "${{ steps.change-set.outputs.change_set }}"
           ACTION="${{ steps.preflight.outputs.stack_action }}"
+
+          set +e
           if [ "$ACTION" = "CREATE" ]; then
             aws cloudformation wait stack-create-complete --stack-name "$STACK"
           else
             aws cloudformation wait stack-update-complete --stack-name "$STACK"
+          fi
+          WAIT_RC=$?
+          set -e
+
+          if [ "$WAIT_RC" -ne 0 ]; then
+            echo "::warning::Stack waiter failed (rc=$WAIT_RC) — capturing failed stack events before teardown"
+            echo "----- describe-stack-events (FAILED only, most-recent 20) -----"
+            aws cloudformation describe-stack-events \
+              --stack-name "$STACK" \
+              --query 'StackEvents[?contains(ResourceStatus, `FAILED`)] | [:20].{Time:Timestamp,LogicalId:LogicalResourceId,Type:ResourceType,Status:ResourceStatus,Reason:ResourceStatusReason}' \
+              --output json || echo "describe-stack-events itself failed"
+            echo "----- end describe-stack-events -----"
+            exit "$WAIT_RC"
           fi
 
       - name: Smoke test — Lambda URL + DDB


### PR DESCRIPTION
## Why

Delta #20 unblocked Create change set (it now succeeds). Execute change set now fails because the stack rolls back to `ROLLBACK_COMPLETE` — some resource failed to create. The always-on teardown then deletes the stack and its events, so we can't see which resource failed.

Same evidence-loss pattern PR #40 fixed for change-set StatusReason. Applying the same pattern to Execute change set.

## Change

Wrap the `aws cloudformation wait stack-create-complete`/`stack-update-complete` waiter with `set +e`, capture the exit code, and on failure print the most-recent 20 FAILED stack events (LogicalResourceId, ResourceType, ResourceStatus, ResourceStatusReason) via `describe-stack-events` before propagating the failure.

## Test plan

1. Merge.
2. Re-dispatch install with version 0.0.0-poc.1.
3. Read failed stack events from workflow logs.
4. Apply next IAM fix (likely missing Lambda/IAM/DDB create permissions on porth-install-role) based on what fails.

## POC waiver

Diagnostic-grade change for active triage on PORTH-459. Same waiver request pattern as PRs #39 / #40.