### PR TITLE
PORTH-459: pass porth-cfn-execution-role to SAR create-change-set (correct architecture)

### DIFF
--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -15,10 +15,6 @@ on:
         description: 'SAR app ARN (out-of-band from publisher). Cross-account-shared SAR apps cannot be discovered via list-applications — that API only returns apps owned by the calling account.'
         required: true
         default: 'arn:aws:serverlessrepo:us-east-1:084847995635:applications/porth-user-management-poc'
-      cfn_execution_role_arn:
-        description: 'CFN service role ARN that the change set will execute under. Holds resource-creation perms (Lambda/DDB/IAM) via the porth-resource-management policy. porth-install-role only needs iam:PassRole on this.'
-        required: true
-        default: 'arn:aws:iam::195950944420:role/porth-cfn-execution-role'
 
 permissions:
   id-token: write
@@ -46,11 +42,6 @@ jobs:
           APP_ARN_INPUT="${{ inputs.application_arn }}"
           if [[ ! "$APP_ARN_INPUT" =~ ^arn:aws:serverlessrepo:[a-z0-9-]+:[0-9]+:applications/[a-zA-Z0-9_-]+$ ]]; then
             echo "::error::Invalid application_arn input: $APP_ARN_INPUT — must be a SAR application ARN"
-            exit 1
-          fi
-          CFN_ROLE_INPUT="${{ inputs.cfn_execution_role_arn }}"
-          if [[ ! "$CFN_ROLE_INPUT" =~ ^arn:aws:iam::[0-9]+:role/porth-cfn-execution-role$ ]]; then
-            echo "::error::Invalid cfn_execution_role_arn input: $CFN_ROLE_INPUT — must match ^arn:aws:iam::[0-9]+:role/porth-cfn-execution-role$"
             exit 1
           fi
 
@@ -152,9 +143,10 @@ jobs:
         # before propagating the failure. Without this, the always-on teardown
         # step deletes the stack and takes the change-set evidence with it.
         # PORTH-459 architecture: --role-arn passes the CFN service role
-        # (porth-cfn-execution-role) so CFN executes the change set under
-        # that role's permissions, not the calling porth-install-role's.
-        # porth-install-role needs iam:PassRole on this target ARN (delta #22).
+        # (porth-cfn-execution-role via env var AWS_CFN_EXECUTION_ROLE_ARN) so
+        # CFN executes the change set under that role's resource-creation
+        # permissions, not the calling porth-install-role's. porth-install-role
+        # needs iam:PassRole on this target ARN (delta #22).
         run: |
           set -euo pipefail
           # serverlessrepo create-cloud-formation-change-set takes the
@@ -168,7 +160,7 @@ jobs:
             --stack-name "$SAR_STACK_NAME" \
             --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
             --parameter-overrides 'Name=Environment,Value=ems-verify' \
-            --role-arn "${{ inputs.cfn_execution_role_arn }}" \
+            --role-arn "${{ vars.AWS_CFN_EXECUTION_ROLE_ARN }}" \
             --query 'ChangeSetId' --output text)
           echo "change_set=$CHANGE_SET" >> "$GITHUB_OUTPUT"
           echo "Created change set: $CHANGE_SET"

--- a/.github/workflows/porth-sar-poc-install.yml
+++ b/.github/workflows/porth-sar-poc-install.yml
@@ -15,6 +15,10 @@ on:
         description: 'SAR app ARN (out-of-band from publisher). Cross-account-shared SAR apps cannot be discovered via list-applications — that API only returns apps owned by the calling account.'
         required: true
         default: 'arn:aws:serverlessrepo:us-east-1:084847995635:applications/porth-user-management-poc'
+      cfn_execution_role_arn:
+        description: 'CFN service role ARN that the change set will execute under. Holds resource-creation perms (Lambda/DDB/IAM) via the porth-resource-management policy. porth-install-role only needs iam:PassRole on this.'
+        required: true
+        default: 'arn:aws:iam::195950944420:role/porth-cfn-execution-role'
 
 permissions:
   id-token: write
@@ -42,6 +46,11 @@ jobs:
           APP_ARN_INPUT="${{ inputs.application_arn }}"
           if [[ ! "$APP_ARN_INPUT" =~ ^arn:aws:serverlessrepo:[a-z0-9-]+:[0-9]+:applications/[a-zA-Z0-9_-]+$ ]]; then
             echo "::error::Invalid application_arn input: $APP_ARN_INPUT — must be a SAR application ARN"
+            exit 1
+          fi
+          CFN_ROLE_INPUT="${{ inputs.cfn_execution_role_arn }}"
+          if [[ ! "$CFN_ROLE_INPUT" =~ ^arn:aws:iam::[0-9]+:role/porth-cfn-execution-role$ ]]; then
+            echo "::error::Invalid cfn_execution_role_arn input: $CFN_ROLE_INPUT — must match ^arn:aws:iam::[0-9]+:role/porth-cfn-execution-role$"
             exit 1
           fi
 
@@ -142,6 +151,10 @@ jobs:
         # describe-change-set and print Status+StatusReason+ExecutionStatus
         # before propagating the failure. Without this, the always-on teardown
         # step deletes the stack and takes the change-set evidence with it.
+        # PORTH-459 architecture: --role-arn passes the CFN service role
+        # (porth-cfn-execution-role) so CFN executes the change set under
+        # that role's permissions, not the calling porth-install-role's.
+        # porth-install-role needs iam:PassRole on this target ARN (delta #22).
         run: |
           set -euo pipefail
           # serverlessrepo create-cloud-formation-change-set takes the
@@ -155,6 +168,7 @@ jobs:
             --stack-name "$SAR_STACK_NAME" \
             --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
             --parameter-overrides 'Name=Environment,Value=ems-verify' \
+            --role-arn "${{ inputs.cfn_execution_role_arn }}" \
             --query 'ChangeSetId' --output text)
           echo "change_set=$CHANGE_SET" >> "$GITHUB_OUTPUT"
           echo "Created change set: $CHANGE_SET"


### PR DESCRIPTION
## Why

Richard identified that the architecture intent is two separate roles:

- `porth-install-role` (GitHub Actions OIDC target) — orchestration perms (SAR + CFN API surface)
- `porth-cfn-execution-role` — resource-creation perms (`porth-resource-management` policy: Lambda/DDB/IAM/etc.)

The workflow currently doesn't pass any service role to SAR's `create-cloud-formation-change-set`, so CFN executes the change set under the calling identity (`porth-install-role`) and trips on missing resource perms (delta #19/#20 diagnostic chain proved this).

Instead of bloating `porth-install-role` with the resource perms it shouldn't own, this PR uses SAR's `--role-arn` parameter to pass `porth-cfn-execution-role`. CFN then assumes that role at change-set execution, and the install proceeds with the correct least-privilege role for each phase.

## Change

- Add `--role-arn "${{ inputs.cfn_execution_role_arn }}"` to the SAR `create-cloud-formation-change-set` call
- Add new workflow_dispatch input `cfn_execution_role_arn` with EMS default (`arn:aws:iam::195950944420:role/porth-cfn-execution-role`)
- Validate that the input matches the expected pattern (security MF9 parity with stack_name/application_arn validation)

## Prerequisite

`porth-install-role` needs `iam:PassRole` on `arn:aws:iam::195950944420:role/porth-cfn-execution-role`. May already be in place — tracked as delta #22 on PORTH-461. If missing, single Sid to add.

## Test plan

1. Merge.
2. Confirm porth-install-role has iam:PassRole on the target (or add it).
3. Re-dispatch install with default version 0.0.0-poc.1.
4. Expect end-to-end green; if not, the FAILED stack events captured by PR #41 will surface the next gap (likely IAM resource naming — porth-resource-management's `IamPorth` Sid scopes to `role/porth-*` but SAR creates roles named `serverlessrepo-porth-*`).

## POC waiver

Same pattern as PRs #39 / #40 / #41 — diagnostic and architectural alignment for PORTH-459 POC tracer.