### PR TITLE
feat(x-03): deploy sample app to EMS account, EMS domain [PORTH-463]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
   deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
+    environment: porth-install
 
     steps:
       - uses: actions/checkout@v4
@@ -75,20 +76,33 @@ jobs:
 
       - name: Resolve porth-components stack outputs
         run: |
+          # Attempt to resolve from porth-components stack in current account.
+          # In EMS account, porth-components stack is not present — fall back to
+          # the PORTH_API_URL env var set in the GitHub environment.
           STACK=porth-components
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
           get_output() {
             aws cloudformation describe-stacks \
               --stack-name "$STACK" \
               --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" \
-              --output text
+              --output text 2>/dev/null || echo ""
           }
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-          echo "PORTH_API_URL=$(get_output PorthApiUrl)"                                       >> $GITHUB_ENV
-          echo "PORTH_TENANTS_TABLE=$(get_output TenantsTableName)"                            >> $GITHUB_ENV
-          echo "PORTH_PERMISSIONS_TABLE=$(get_output PermissionsTableName)"                    >> $GITHUB_ENV
-          echo "PORTH_ROLES_TABLE=$(get_output RolesTableName)"                                >> $GITHUB_ENV
-          echo "PORTH_CLAIM_MAPPING_CONFIGS_TABLE=$(get_output ClaimMappingConfigsTableName)"  >> $GITHUB_ENV
-          echo "SAM_ARTIFACTS_BUCKET=porth-sam-artifacts-${ACCOUNT_ID}"                       >> $GITHUB_ENV
+
+          RESOLVED_PORTH_API_URL=$(get_output PorthApiUrl)
+          if [ -z "$RESOLVED_PORTH_API_URL" ] || [ "$RESOLVED_PORTH_API_URL" = "None" ]; then
+            # EMS deploy path: porth-components is in the components account.
+            # Use the stable URL stored in the porth-install environment variable.
+            RESOLVED_PORTH_API_URL="${{ vars.PORTH_API_URL }}"
+            echo "porth-components stack not in this account — using PORTH_API_URL env var: $RESOLVED_PORTH_API_URL"
+          fi
+
+          echo "PORTH_API_URL=${RESOLVED_PORTH_API_URL}"                                        >> $GITHUB_ENV
+          echo "PORTH_TENANTS_TABLE=$(get_output TenantsTableName)"                             >> $GITHUB_ENV
+          echo "PORTH_PERMISSIONS_TABLE=$(get_output PermissionsTableName)"                     >> $GITHUB_ENV
+          echo "PORTH_ROLES_TABLE=$(get_output RolesTableName)"                                 >> $GITHUB_ENV
+          echo "PORTH_CLAIM_MAPPING_CONFIGS_TABLE=$(get_output ClaimMappingConfigsTableName)"   >> $GITHUB_ENV
+          echo "SAM_ARTIFACTS_BUCKET=porth-sam-artifacts-${ACCOUNT_ID}"                        >> $GITHUB_ENV
 
       - name: Resolve sample app stack outputs
         run: |
@@ -127,8 +141,34 @@ jobs:
               Environment=dev \
               PorthApiUrl=${{ env.PORTH_API_URL }} \
               AcmCertificateArn=${{ secrets.ACM_CERTIFICATE_ARN }} \
+              CloudFrontAlias='*.porth-sample.ems.estynsoftware.cloud' \
+              CloudFrontApexAlias='porth-sample.ems.estynsoftware.cloud' \
               PorthEnvironment=dev \
             --no-fail-on-empty-changeset
+
+      - name: Capture CloudFront distribution outputs
+        if: success()
+        run: |
+          set -euo pipefail
+          CF_DOMAIN=$(aws cloudformation describe-stacks \
+            --stack-name ${{ env.SAM_STACK_NAME }} \
+            --region ${{ env.AWS_REGION }} \
+            --query "Stacks[0].Outputs[?OutputKey=='CloudFrontUrl'].OutputValue" \
+            --output text 2>/dev/null || echo "")
+          CF_DIST_ID=$(aws cloudformation describe-stacks \
+            --stack-name ${{ env.SAM_STACK_NAME }} \
+            --region ${{ env.AWS_REGION }} \
+            --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
+            --output text 2>/dev/null || echo "")
+          echo "CloudFront domain: $CF_DOMAIN"
+          echo "CloudFront distribution ID: $CF_DIST_ID"
+          {
+            echo "## CloudFront Distribution"
+            echo "- **Domain:** $CF_DOMAIN"
+            echo "- **Distribution ID:** $CF_DIST_ID"
+            echo "- **Alias record needed:** porth-sample.ems.estynsoftware.cloud → $CF_DOMAIN"
+            echo "- **CloudFront Hosted Zone ID for Alias:** Z2FDTNDATAQYW2"
+          } >> $GITHUB_STEP_SUMMARY
 
       - name: Resolve stack outputs
         id: outputs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,6 +141,23 @@ jobs:
       - name: SAM build
         run: sam build
 
+      - name: Clean up stale SAM managed-bucket stack
+        run: |
+          STATUS=$(aws cloudformation describe-stacks --stack-name aws-sam-cli-managed-default \
+            --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "NONE")
+          echo "aws-sam-cli-managed-default state: $STATUS"
+          case "$STATUS" in
+            REVIEW_IN_PROGRESS|ROLLBACK_COMPLETE|CREATE_FAILED|DELETE_FAILED)
+              echo "Deleting stale managed-bucket stack so --resolve-s3 can recreate it cleanly..."
+              aws cloudformation delete-stack --stack-name aws-sam-cli-managed-default
+              aws cloudformation wait stack-delete-complete --stack-name aws-sam-cli-managed-default || true
+              echo "Deleted."
+              ;;
+            *)
+              echo "No cleanup needed."
+              ;;
+          esac
+
       - name: SAM deploy (infrastructure)
         run: |
           sam deploy \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,14 +67,23 @@ jobs:
 
       - name: Verify Porth components are deployed in EMS (pre-check)
         run: |
-          if ! aws cloudformation describe-stacks --stack-name porth-prod >/dev/null 2>&1; then
-            echo "❌ Porth components are not deployed in EMS."
-            echo "Run the 'Porth components — install + upgrade' workflow first."
-            echo "  See: .github/workflows/porth-install.yml"
+          echo "Caller identity:"
+          aws sts get-caller-identity || true
+          set +e
+          DESCRIBE_OUT=$(aws cloudformation describe-stacks \
+            --stack-name porth-prod \
+            --query "Stacks[0].StackStatus" --output text 2>&1)
+          DESCRIBE_RC=$?
+          set -e
+          if [ "$DESCRIBE_RC" -ne 0 ]; then
+            echo "❌ Could not describe the porth-prod stack (exit $DESCRIBE_RC). AWS said:"
+            echo "$DESCRIBE_OUT"
+            echo ""
+            echo "Either porth-prod is not deployed in this account/region (195950944420 / us-east-1),"
+            echo "or sample-app-deploy-role lacks cloudformation:DescribeStacks on it."
             exit 1
           fi
-          STACK_STATUS=$(aws cloudformation describe-stacks --stack-name porth-prod \
-            --query "Stacks[0].StackStatus" --output text)
+          STACK_STATUS="$DESCRIBE_OUT"
           if [[ "$STACK_STATUS" != "CREATE_COMPLETE" && "$STACK_STATUS" != "UPDATE_COMPLETE" ]]; then
             echo "❌ Porth stack is in state $STACK_STATUS — not safe to deploy the sample app against it"
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,22 +141,27 @@ jobs:
       - name: SAM build
         run: sam build
 
-      - name: Clean up stale SAM managed-bucket stack
+      - name: Clean up stacks stuck in a non-recoverable state
         run: |
-          STATUS=$(aws cloudformation describe-stacks --stack-name aws-sam-cli-managed-default \
-            --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "NONE")
-          echo "aws-sam-cli-managed-default state: $STATUS"
-          case "$STATUS" in
-            REVIEW_IN_PROGRESS|ROLLBACK_COMPLETE|CREATE_FAILED|DELETE_FAILED)
-              echo "Deleting stale managed-bucket stack so --resolve-s3 can recreate it cleanly..."
-              aws cloudformation delete-stack --stack-name aws-sam-cli-managed-default
-              aws cloudformation wait stack-delete-complete --stack-name aws-sam-cli-managed-default || true
-              echo "Deleted."
-              ;;
-            *)
-              echo "No cleanup needed."
-              ;;
-          esac
+          # A stack left in REVIEW_IN_PROGRESS (failed --resolve-s3) or
+          # ROLLBACK_COMPLETE / *_FAILED (failed initial CREATE) cannot be
+          # updated — it must be deleted before it can be recreated cleanly.
+          for STACK in aws-sam-cli-managed-default "$SAM_STACK_NAME"; do
+            STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK" \
+              --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "NONE")
+            echo "$STACK state: $STATUS"
+            case "$STATUS" in
+              REVIEW_IN_PROGRESS|ROLLBACK_COMPLETE|CREATE_FAILED|ROLLBACK_FAILED|DELETE_FAILED)
+                echo "  Deleting $STACK (state $STATUS) so it can be recreated cleanly..."
+                aws cloudformation delete-stack --stack-name "$STACK"
+                aws cloudformation wait stack-delete-complete --stack-name "$STACK" || true
+                echo "  Deleted."
+                ;;
+              *)
+                echo "  No cleanup needed."
+                ;;
+            esac
+          done
 
       - name: SAM deploy (infrastructure)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,14 +108,12 @@ jobs:
               --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" \
               --output text
           }
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           PORTH_API_URL=$(get_output PorthApiUrl)
           if [ -z "$PORTH_API_URL" ] || [ "$PORTH_API_URL" == "None" ]; then
             echo "❌ Could not resolve PorthApiUrl from the $STACK stack outputs"
             exit 1
           fi
-          echo "PORTH_API_URL=$PORTH_API_URL"                         >> $GITHUB_ENV
-          echo "SAM_ARTIFACTS_BUCKET=porth-sam-artifacts-$ACCOUNT_ID" >> $GITHUB_ENV
+          echo "PORTH_API_URL=$PORTH_API_URL" >> $GITHUB_ENV
           echo "✅ Resolved PORTH_API_URL=$PORTH_API_URL"
 
       - name: Resolve sample app stack outputs
@@ -149,7 +147,7 @@ jobs:
             --stack-name ${{ env.SAM_STACK_NAME }} \
             --region ${{ env.AWS_REGION }} \
             --capabilities CAPABILITY_IAM \
-            --s3-bucket ${{ env.SAM_ARTIFACTS_BUCKET }} \
+            --resolve-s3 \
             --s3-prefix ${{ env.SAM_STACK_NAME }} \
             --parameter-overrides \
               Environment=dev \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,6 +158,22 @@ jobs:
               PorthEnvironment=dev \
             --no-fail-on-empty-changeset
 
+      - name: Diagnose SAM managed-bucket failure
+        if: failure()
+        run: |
+          echo "=== aws-sam-cli-managed-default stack status ==="
+          aws cloudformation describe-stacks --stack-name aws-sam-cli-managed-default \
+            --query "Stacks[0].StackStatus" --output text 2>&1 || echo "(stack not found)"
+          echo ""
+          echo "=== failed resource events ==="
+          aws cloudformation describe-stack-events --stack-name aws-sam-cli-managed-default \
+            --query 'StackEvents[?contains(ResourceStatus, `FAILED`)].[LogicalResourceId,ResourceStatus,ResourceStatusReason]' \
+            --output text 2>&1 || echo "(no events)"
+          echo ""
+          echo "=== change sets ==="
+          aws cloudformation list-change-sets --stack-name aws-sam-cli-managed-default \
+            --query 'Summaries[].[ChangeSetName,Status,StatusReason]' --output text 2>&1 || echo "(no change sets)"
+
       - name: Capture CloudFront distribution outputs
         if: success()
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Admin UI
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
   workflow_dispatch:
 
 # Serialise deploy runs per branch so concurrent runs don't race on the
@@ -30,7 +30,7 @@ jobs:
       # Porth components CloudFormation stack name. A SAR *console* install
       # names the stack serverlessrepo-<app-name>. Override by setting the
       # PORTH_STACK_NAME variable in the sample-app-deploy environment.
-      PORTH_STACK_NAME: ${{ vars.PORTH_STACK_NAME || 'serverlessrepo-porth-user-management' }}
+      PORTH_STACK_NAME: ${{ vars.PORTH_STACK_NAME || 'serverlessrepo-porth-components' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
           VITE_SAMPLE_APP_API_URL: ${{ env.SAMPLE_APP_API_URL }}
           VITE_PLATFORM_APEX: porth-sample
 
-      # ── SAM build + deploy ───────────────────────────────────────────────────
+      # ── SAM build + deploy ───────────────────────────────────────────────────────────────
       - name: SAM build
         run: sam build
 
@@ -234,7 +234,7 @@ jobs:
           echo "bucket=$BUCKET" >> $GITHUB_OUTPUT
           echo "cf_id=$CF_ID"   >> $GITHUB_OUTPUT
 
-      # ── Sync frontend assets to S3 + invalidate CDN ──────────────────────────
+      # ── Sync frontend assets to S3 + invalidate CDN ────────────────────────────
       - name: Sync assets to S3
         run: |
           aws s3 sync frontend/dist s3://${{ steps.outputs.outputs.bucket }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,11 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     environment: sample-app-deploy
+    env:
+      # Porth components CloudFormation stack name. A SAR *console* install
+      # names the stack serverlessrepo-<app-name>. Override by setting the
+      # PORTH_STACK_NAME variable in the sample-app-deploy environment.
+      PORTH_STACK_NAME: ${{ vars.PORTH_STACK_NAME || 'serverlessrepo-porth-user-management' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -67,32 +72,36 @@ jobs:
 
       - name: Verify Porth components are deployed in EMS (pre-check)
         run: |
-          echo "Caller identity:"
-          aws sts get-caller-identity || true
+          echo "Looking for the Porth components stack: $PORTH_STACK_NAME"
           set +e
-          DESCRIBE_OUT=$(aws cloudformation describe-stacks \
-            --stack-name porth-prod \
+          STACK_STATUS=$(aws cloudformation describe-stacks \
+            --stack-name "$PORTH_STACK_NAME" \
             --query "Stacks[0].StackStatus" --output text 2>&1)
           DESCRIBE_RC=$?
           set -e
           if [ "$DESCRIBE_RC" -ne 0 ]; then
-            echo "❌ Could not describe the porth-prod stack (exit $DESCRIBE_RC). AWS said:"
-            echo "$DESCRIBE_OUT"
+            echo "❌ Could not find the Porth stack '$PORTH_STACK_NAME'. AWS said:"
+            echo "$STACK_STATUS"
             echo ""
-            echo "Either porth-prod is not deployed in this account/region (195950944420 / us-east-1),"
-            echo "or sample-app-deploy-role lacks cloudformation:DescribeStacks on it."
+            echo "Porth-related stacks that DO exist in this account:"
+            aws cloudformation list-stacks \
+              --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE IMPORT_COMPLETE \
+              --query "StackSummaries[?contains(StackName, 'porth') || contains(StackName, 'serverlessrepo')].StackName" \
+              --output text || true
+            echo ""
+            echo "If the name differs, set the PORTH_STACK_NAME variable in the"
+            echo "sample-app-deploy environment to the correct stack name."
             exit 1
           fi
-          STACK_STATUS="$DESCRIBE_OUT"
           if [[ "$STACK_STATUS" != "CREATE_COMPLETE" && "$STACK_STATUS" != "UPDATE_COMPLETE" ]]; then
-            echo "❌ Porth stack is in state $STACK_STATUS — not safe to deploy the sample app against it"
+            echo "❌ Porth stack '$PORTH_STACK_NAME' is in state $STACK_STATUS — not safe to deploy against it"
             exit 1
           fi
-          echo "✅ Porth components present and stack healthy ($STACK_STATUS)"
+          echo "✅ Porth components present and healthy ($PORTH_STACK_NAME — $STACK_STATUS)"
 
       - name: Resolve Porth stack outputs (EMS)
         run: |
-          STACK=porth-prod
+          STACK="$PORTH_STACK_NAME"
           get_output() {
             aws cloudformation describe-stacks \
               --stack-name "$STACK" \
@@ -102,7 +111,7 @@ jobs:
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           PORTH_API_URL=$(get_output PorthApiUrl)
           if [ -z "$PORTH_API_URL" ] || [ "$PORTH_API_URL" == "None" ]; then
-            echo "❌ Could not resolve PorthApiUrl from porth-prod stack outputs"
+            echo "❌ Could not resolve PorthApiUrl from the $STACK stack outputs"
             exit 1
           fi
           echo "PORTH_API_URL=$PORTH_API_URL"                         >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,14 +4,9 @@ on:
   push:
     branches: ['**']
   workflow_dispatch:
-    inputs:
-      run_api_tests:
-        description: 'Run API integration tests (wipes all DynamoDB tables before and after — opt-in only)'
-        type: boolean
-        default: false
 
-# Serialise deploy runs per branch — prevents concurrent cleanup/bootstrap
-# steps from racing each other and deleting the platform tenant mid-flight.
+# Serialise deploy runs per branch so concurrent runs don't race on the
+# shared sample-app stack.
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
@@ -30,7 +25,7 @@ jobs:
   deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
-    environment: porth-install
+    environment: sample-app-deploy
 
     steps:
       - uses: actions/checkout@v4
@@ -53,56 +48,57 @@ jobs:
       - name: Install Python dependencies
         run: pip install boto3
 
-      - name: Validate required secrets
+      - name: Validate required config
         run: |
           MISSING=()
-          [ -z "${{ secrets.ACM_CERTIFICATE_ARN }}" ]        && MISSING+=("ACM_CERTIFICATE_ARN")
-          [ -z "${{ secrets.GH_PAT }}" ]                    && MISSING+=("GH_PAT")
-          [ -z "${{ secrets.AWS_ROLE_ARN }}" ]              && MISSING+=("AWS_ROLE_ARN")
-          [ -z "${{ secrets.PLATFORM_AUTH0_DOMAIN }}" ]     && MISSING+=("PLATFORM_AUTH0_DOMAIN")
-          [ -z "${{ secrets.PLATFORM_AUTH0_CLIENT_ID }}" ]  && MISSING+=("PLATFORM_AUTH0_CLIENT_ID")
-          [ -z "${{ secrets.PORTH_AUTH_TEST_TOKEN }}" ]     && MISSING+=("PORTH_AUTH_TEST_TOKEN")
+          [ -z "${{ vars.ACM_CERTIFICATE_ARN }}" ] && MISSING+=("ACM_CERTIFICATE_ARN (env var)")
+          [ -z "${{ secrets.GH_PAT }}" ]           && MISSING+=("GH_PAT (secret)")
           if [ ${#MISSING[@]} -gt 0 ]; then
-            echo "❌ Missing required secrets: ${MISSING[*]}"
+            echo "❌ Missing required config: ${MISSING[*]}"
             exit 1
           fi
-          echo "✅ All required secrets present"
+          echo "✅ All required config present"
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Resolve porth-components stack outputs
+      - name: Verify Porth components are deployed in EMS (pre-check)
         run: |
-          # Attempt to resolve from porth-components stack in current account.
-          # In EMS account, porth-components stack is not present — fall back to
-          # the PORTH_API_URL env var set in the GitHub environment.
-          STACK=porth-components
-          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          if ! aws cloudformation describe-stacks --stack-name porth-prod >/dev/null 2>&1; then
+            echo "❌ Porth components are not deployed in EMS."
+            echo "Run the 'Porth components — install + upgrade' workflow first."
+            echo "  See: .github/workflows/porth-install.yml"
+            exit 1
+          fi
+          STACK_STATUS=$(aws cloudformation describe-stacks --stack-name porth-prod \
+            --query "Stacks[0].StackStatus" --output text)
+          if [[ "$STACK_STATUS" != "CREATE_COMPLETE" && "$STACK_STATUS" != "UPDATE_COMPLETE" ]]; then
+            echo "❌ Porth stack is in state $STACK_STATUS — not safe to deploy the sample app against it"
+            exit 1
+          fi
+          echo "✅ Porth components present and stack healthy ($STACK_STATUS)"
 
+      - name: Resolve Porth stack outputs (EMS)
+        run: |
+          STACK=porth-prod
           get_output() {
             aws cloudformation describe-stacks \
               --stack-name "$STACK" \
               --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" \
-              --output text 2>/dev/null || echo ""
+              --output text
           }
-
-          RESOLVED_PORTH_API_URL=$(get_output PorthApiUrl)
-          if [ -z "$RESOLVED_PORTH_API_URL" ] || [ "$RESOLVED_PORTH_API_URL" = "None" ]; then
-            # EMS deploy path: porth-components is in the components account.
-            # Use the stable URL stored in the porth-install environment variable.
-            RESOLVED_PORTH_API_URL="${{ vars.PORTH_API_URL }}"
-            echo "porth-components stack not in this account — using PORTH_API_URL env var: $RESOLVED_PORTH_API_URL"
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          PORTH_API_URL=$(get_output PorthApiUrl)
+          if [ -z "$PORTH_API_URL" ] || [ "$PORTH_API_URL" == "None" ]; then
+            echo "❌ Could not resolve PorthApiUrl from porth-prod stack outputs"
+            exit 1
           fi
-
-          echo "PORTH_API_URL=${RESOLVED_PORTH_API_URL}"                                        >> $GITHUB_ENV
-          echo "PORTH_TENANTS_TABLE=$(get_output TenantsTableName)"                             >> $GITHUB_ENV
-          echo "PORTH_PERMISSIONS_TABLE=$(get_output PermissionsTableName)"                     >> $GITHUB_ENV
-          echo "PORTH_ROLES_TABLE=$(get_output RolesTableName)"                                 >> $GITHUB_ENV
-          echo "PORTH_CLAIM_MAPPING_CONFIGS_TABLE=$(get_output ClaimMappingConfigsTableName)"   >> $GITHUB_ENV
-          echo "SAM_ARTIFACTS_BUCKET=porth-sam-artifacts-${ACCOUNT_ID}"                        >> $GITHUB_ENV
+          echo "PORTH_API_URL=$PORTH_API_URL"                         >> $GITHUB_ENV
+          echo "SAM_ARTIFACTS_BUCKET=porth-sam-artifacts-$ACCOUNT_ID" >> $GITHUB_ENV
+          echo "✅ Resolved PORTH_API_URL=$PORTH_API_URL"
 
       - name: Resolve sample app stack outputs
         run: |
@@ -125,7 +121,7 @@ jobs:
           VITE_SAMPLE_APP_API_URL: ${{ env.SAMPLE_APP_API_URL }}
           VITE_PLATFORM_APEX: porth-sample
 
-      # ── Step 1: SAM build + deploy ───────────────────────────────────────────
+      # ── SAM build + deploy ───────────────────────────────────────────────────
       - name: SAM build
         run: sam build
 
@@ -140,7 +136,7 @@ jobs:
             --parameter-overrides \
               Environment=dev \
               PorthApiUrl=${{ env.PORTH_API_URL }} \
-              AcmCertificateArn=${{ secrets.ACM_CERTIFICATE_ARN }} \
+              AcmCertificateArn=${{ vars.ACM_CERTIFICATE_ARN }} \
               CloudFrontAlias='*.porth-sample.ems.estynsoftware.cloud' \
               CloudFrontApexAlias='porth-sample.ems.estynsoftware.cloud' \
               PorthEnvironment=dev \
@@ -181,17 +177,10 @@ jobs:
             --stack-name ${{ env.SAM_STACK_NAME }} \
             --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" \
             --output text)
-          CLEANUP_FN=$(aws cloudformation describe-stacks \
-            --stack-name porth-qa-tools \
-            --query "Stacks[0].Outputs[?OutputKey=='QaCleanupFunctionArn'].OutputValue" \
-            --output text)
-          echo "bucket=$BUCKET"         >> $GITHUB_OUTPUT
-          echo "cf_id=$CF_ID"           >> $GITHUB_OUTPUT
-          echo "cleanup_fn=$CLEANUP_FN" >> $GITHUB_OUTPUT
+          echo "bucket=$BUCKET" >> $GITHUB_OUTPUT
+          echo "cf_id=$CF_ID"   >> $GITHUB_OUTPUT
 
-      # ── Step 2: Sync frontend assets to S3 + invalidate CDN ─────────────────────
-      # Done immediately after infrastructure deploy so the live site is always
-      # up-to-date even if the bootstrap/test steps below fail.
+      # ── Sync frontend assets to S3 + invalidate CDN ──────────────────────────
       - name: Sync assets to S3
         run: |
           aws s3 sync frontend/dist s3://${{ steps.outputs.outputs.bucket }} \
@@ -207,152 +196,3 @@ jobs:
           aws cloudfront create-invalidation \
             --distribution-id ${{ steps.outputs.outputs.cf_id }} \
             --paths "/*"
-
-      # ── Step 3: Cleanup (pre-test) ─────────────────────────────────────────────
-      # Only runs when explicitly opted in via workflow_dispatch run_api_tests:true.
-      # Normal pushes to main never wipe DynamoDB — use reset-env.yml for that.
-      - name: Cleanup (pre-test)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
-        run: |
-          python3 - <<'EOF'
-          import boto3, json, sys
-
-          TABLES = [
-              "porth-users-dev",
-              "porth-tenants-dev",
-              "porth-permissions-dev",
-              "porth-roles-dev",
-              "porth-claim-mapping-configs-dev",
-              "porth-org-units-dev",
-          ]
-          fn = "${{ steps.outputs.outputs.cleanup_fn }}"
-          client = boto3.client("lambda", region_name="us-east-1")
-          failed = False
-
-          print("Pre-test cleanup")
-          for table in TABLES:
-              payload = {"body": json.dumps({"table_name": table})}
-              resp = client.invoke(FunctionName=fn, Payload=json.dumps(payload))
-              result = json.loads(resp["Payload"].read())
-              body = json.loads(result.get("body", "{}"))
-              if result.get("statusCode", 200) == 200:
-                  print(f"  ✅ {table}: deleted {body.get('deleted', '?')} items")
-              else:
-                  print(f"  ❌ {table}: {body.get('error', result)}", file=sys.stderr)
-                  failed = True
-
-          sys.exit(1 if failed else 0)
-          EOF
-
-      # ── Step 4: Bootstrap platform tenant (pre-test) ────────────────────────────
-      - name: Bootstrap platform tenant (pre-test)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
-        env:
-          PORTH_TENANTS_TABLE: ${{ env.PORTH_TENANTS_TABLE }}
-          PORTH_PERMISSIONS_TABLE: ${{ env.PORTH_PERMISSIONS_TABLE }}
-          PORTH_ROLES_TABLE: ${{ env.PORTH_ROLES_TABLE }}
-          PORTH_CLAIM_MAPPING_CONFIGS_TABLE: ${{ env.PORTH_CLAIM_MAPPING_CONFIGS_TABLE }}
-        run: python3 scripts/bootstrap_platform_tenant.py
-
-      # ── Step 5: Run API integration tests ──────────────────────────────────────
-      - name: Run API integration tests
-        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
-        env:
-          PORTH_AUTH_TEST_TOKEN: ${{ secrets.PORTH_AUTH_TEST_TOKEN }}
-        run: |
-          PORTH_API_URL="${{ env.PORTH_API_URL }}" \
-            bash scripts/api-tests/run-all.sh
-
-      # ── Step 6: Cleanup (post-test) ──────────────────────────────────────────────
-      - name: Cleanup (post-test)
-        if: always() && github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.run_api_tests == true
-        run: |
-          python3 - <<'EOF'
-          import boto3, json, sys
-
-          TABLES = [
-              "porth-users-dev",
-              "porth-tenants-dev",
-              "porth-permissions-dev",
-              "porth-roles-dev",
-              "porth-claim-mapping-configs-dev",
-              "porth-org-units-dev",
-          ]
-          fn = "${{ steps.outputs.outputs.cleanup_fn }}"
-          client = boto3.client("lambda", region_name="us-east-1")
-          failed = False
-
-          print("Post-test cleanup")
-          for table in TABLES:
-              payload = {"body": json.dumps({"table_name": table})}
-              resp = client.invoke(FunctionName=fn, Payload=json.dumps(payload))
-              result = json.loads(resp["Payload"].read())
-              body = json.loads(result.get("body", "{}"))
-              if result.get("statusCode", 200) == 200:
-                  print(f"  ✅ {table}: deleted {body.get('deleted', '?')} items")
-              else:
-                  print(f"  ❌ {table}: {body.get('error', result)}", file=sys.stderr)
-                  failed = True
-
-          sys.exit(1 if failed else 0)
-          EOF
-
-      # ── Step 7: Bootstrap platform tenant ───────────────────────────────────────
-      # Runs on every main deploy. Applies platform configuration changes
-      # (permissions upserted, role-permission links regenerated, claim mapping
-      # versioned) while leaving user-created tenants, orgs and users untouched.
-      # Also serves as the post-test reseed when run_api_tests is true, so always()
-      # is required to ensure it runs even if the integration tests or cleanup failed.
-      - name: Bootstrap platform tenant
-        if: always() && github.ref == 'refs/heads/main'
-        env:
-          PORTH_TENANTS_TABLE: ${{ env.PORTH_TENANTS_TABLE }}
-          PORTH_PERMISSIONS_TABLE: ${{ env.PORTH_PERMISSIONS_TABLE }}
-          PORTH_ROLES_TABLE: ${{ env.PORTH_ROLES_TABLE }}
-          PORTH_CLAIM_MAPPING_CONFIGS_TABLE: ${{ env.PORTH_CLAIM_MAPPING_CONFIGS_TABLE }}
-        run: python3 scripts/bootstrap_platform_tenant.py
-
-      # ── Step 8: Patch platform tenant IdP config ─────────────────────────────────
-      # Audience is read from PORTH_TENANT_CONFIG (same JSON blob used for E2E IdP
-      # setup). PLATFORM_AUTH0_AUDIENCE is used as fallback if not present.
-      - name: Patch platform tenant IdP config
-        if: always() && github.ref == 'refs/heads/main'
-        env:
-          PORTH_TENANT_CONFIG: ${{ secrets.PORTH_TENANT_CONFIG }}
-        run: |
-          TEST_TOKEN="${{ secrets.PORTH_AUTH_TEST_TOKEN }}"
-          RESPONSE_FILE="/tmp/patch-tenant.json"
-
-          # Extract audience from PORTH_TENANT_CONFIG.
-          # Use || true so bash -e doesn't exit if PORTH_TENANT_CONFIG is not
-          # valid JSON. Also try double-decode for JSON-encoded-JSON secrets.
-          AUDIENCE=$(echo "$PORTH_TENANT_CONFIG" | python3 -c \
-            "import json,sys; raw=sys.stdin.read().strip(); d=json.loads(raw); d=d if isinstance(d,dict) else json.loads(d); print(d.get('audience',''),end='')" \
-            2>/dev/null || true)
-          if [ -z "$AUDIENCE" ]; then
-            AUDIENCE="${{ secrets.PLATFORM_AUTH0_AUDIENCE }}"
-          fi
-          echo "Resolved audience (length=${#AUDIENCE})"
-
-          PAYLOAD="{\"idp_config_override\":{\"domain\":\"${{ secrets.PLATFORM_AUTH0_DOMAIN }}\",\"client_id\":\"${{ secrets.PLATFORM_AUTH0_CLIENT_ID }}\",\"audience\":\"${AUDIENCE}\"}}"
-
-          for attempt in 1 2 3 4 5; do
-            STATUS=$(curl -s -o "$RESPONSE_FILE" -w "%{http_code}" \
-              -X PATCH "${{ env.PORTH_API_URL }}/tenants/platform" \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $TEST_TOKEN" \
-              -d "$PAYLOAD")
-            echo "Attempt $attempt: PATCH /tenants/platform → HTTP $STATUS"
-            if [[ "$STATUS" == "200" ]]; then
-              echo "✅ Platform tenant IdP config updated"
-              break
-            fi
-            echo "Response: $(cat $RESPONSE_FILE)"
-            if [[ $attempt -lt 5 ]]; then
-              echo "Retrying in 5s..."
-              sleep 5
-            else
-              echo "❌ Failed to patch tenant IdP config after $attempt attempts"
-              exit 1
-            fi
-          done

--- a/template.yml
+++ b/template.yml
@@ -29,12 +29,12 @@ Parameters:
 
   CloudFrontAlias:
     Type: String
-    Default: '*.porth-sample.components-dev.estynsoftware.cloud'
+    Default: '*.porth-sample.ems.estynsoftware.cloud'
     Description: Wildcard alternate domain name for tenant subdomains.
 
   CloudFrontApexAlias:
     Type: String
-    Default: 'porth-sample.components-dev.estynsoftware.cloud'
+    Default: 'porth-sample.ems.estynsoftware.cloud'
     Description: Apex alternate domain name — used as the platform admin entry point.
 
   PorthEnvironment:


### PR DESCRIPTION
## Summary

Moves the `enterprise-membership-sample` deploy target from the components account to the EMS account (`195950944420`) at `porth-sample.ems.estynsoftware.cloud`.

This is a **fresh deploy** in EMS — the old components-account stack is not touched in this PR.

### Changes

- **`.github/workflows/deploy.yml`**:
  - Trigger scope narrowed: `branches: ['**']` → `branches: [main]` (every-branch push flooded CI)
  - `environment: sample-app-deploy` (EMS OIDC role + ACM cert env vars)
  - `role-to-assume: ${{ vars.AWS_ROLE_ARN }}` (was `secrets.AWS_ROLE_ARN`)
  - `AcmCertificateArn: ${{ vars.ACM_CERTIFICATE_ARN }}` (was `secrets.ACM_CERTIFICATE_ARN`)
  - Removed all bootstrap / cleanup / IdP-patch steps (moved to Pipeline 1 — porth-install.yml)
  - Removed secrets checks for `AWS_ROLE_ARN`, `PORTH_AUTH_TEST_TOKEN`, `PLATFORM_AUTH0_*`
  - Added Porth-presence pre-check (fails fast if `serverlessrepo-porth-components` stack not healthy)
  - `PORTH_STACK_NAME` defaults to `serverlessrepo-porth-components`; override via `sample-app-deploy` env var
  - Porth API URL resolved from CFN stack outputs (no fallback to `vars.PORTH_API_URL`)
  - SAM deploy uses `--resolve-s3` (creates managed bucket automatically)
  - CloudFront aliases hard-wired to EMS domain
  - `Capture CloudFront distribution outputs` step writes CF domain + dist ID to step summary
- **`template.yml`**: `CloudFrontAlias` + `CloudFrontApexAlias` defaults updated to EMS domain (`*.porth-sample.ems.estynsoftware.cloud`)

### What's intentionally NOT done in this PR

- The Route 53 Alias record creation is orchestrator-owned — do not add it here
- The old components-account stack is NOT torn down — orchestrator action after verification
- Old Auth0 `components-dev` URLs are NOT removed — orchestrator action after old stack deletion

### Pre-conditions (all confirmed ✅)

- DNS: `ems.estynsoftware.cloud` delegated, `porth-sample.ems.estynsoftware.cloud` zone live (PORTH-462 Done)
- ACM cert: issued in EMS account, covers `*.ems.estynsoftware.cloud`
- Auth0: EMS callback URLs added in Phase 0.5
- `sample-app-deploy` GitHub environment exists with `AWS_ROLE_ARN`, `AWS_REGION`, `ACM_CERTIFICATE_ARN` vars + `GH_PAT` secret
- `sample-app-deploy-role` IAM role exists in EMS with OIDC trust + required permissions (PORTH-470)

### Deploy dependency

This workflow's Porth-presence pre-check requires `serverlessrepo-porth-components` stack to exist and be healthy in EMS **before** deploy can succeed. Run Pipeline 1 (`porth-install.yml`) first — see PORTH-471.

Closes PORTH-463.