### PR TITLE
fix(deploy): correct stack names + bump porth-install to SAR v0.0.6 [PORTH-471/473]

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -4,6 +4,11 @@ name: Bootstrap Platform Tenant
 # resets the DynamoDB tables.  Idempotent — safe to run multiple times.
 on:
   workflow_dispatch:
+    inputs:
+      stack_name:
+        description: 'CloudFormation stack name for porth-components'
+        required: false
+        default: 'serverlessrepo-porth-components'
 
 permissions:
   id-token: write
@@ -33,7 +38,7 @@ jobs:
 
       - name: Resolve porth-components stack outputs
         run: |
-          STACK=porth-components
+          STACK="${{ inputs.stack_name || 'serverlessrepo-porth-components' }}"
           get_output() {
             aws cloudformation describe-stacks \
               --stack-name "$STACK" \
@@ -44,6 +49,68 @@ jobs:
           echo "PORTH_PERMISSIONS_TABLE=$(get_output PermissionsTableName)"                    >> $GITHUB_ENV
           echo "PORTH_ROLES_TABLE=$(get_output RolesTableName)"                                >> $GITHUB_ENV
           echo "PORTH_CLAIM_MAPPING_CONFIGS_TABLE=$(get_output ClaimMappingConfigsTableName)"  >> $GITHUB_ENV
+
+      # ── Seed SSM auth-policy + session-policy templates ─────────────────────
+      # These params are required by the AuthorizerFunction policy cache.
+      # The porth-install OIDC role doesn't have ssm:PutParameter, so seeding
+      # is done here using secrets.AWS_ROLE_ARN (the broader deploy role).
+      # Environment is derived from the table names (suffix after the last dash).
+      - name: Seed SSM auth-policy templates
+        run: |
+          set -euo pipefail
+          # Derive env from the resolved table name (e.g. porth-tenants-dev → dev)
+          ENV=$(echo "$PORTH_PERMISSIONS_TABLE" | awk -F'-' '{print $NF}')
+          echo "Seeding SSM params for environment: $ENV"
+
+          ALLOW_ALL='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"execute-api:Invoke","Resource":"*"}]}'
+          INDEX='{ "/organizations":"platform-admin-only", "/tenants":"tenant-scoped-rbac", "/users":"tenant-scoped-user", "/roles":"tenant-scoped-rbac", "/permissions":"tenant-scoped-rbac", "/claim-mapping-configs":"tenant-scoped-rbac", "/org-units":"tenant-scoped-rbac", "/provision":"tenant-scoped-user" }'
+
+          for NAME in \
+            "/porth/${ENV}/auth-policy/platform-admin-only:$ALLOW_ALL" \
+            "/porth/${ENV}/auth-policy/tenant-scoped-rbac:$ALLOW_ALL" \
+            "/porth/${ENV}/auth-policy/tenant-scoped-user:$ALLOW_ALL"
+          do
+            PARAM="${NAME%%:*}"
+            VALUE="${NAME#*:}"
+            aws ssm put-parameter \
+              --name "$PARAM" \
+              --value "$VALUE" \
+              --type String \
+              --overwrite \
+              --region "$AWS_REGION" \
+              --no-cli-pager
+            echo "✅ $PARAM"
+          done
+
+          aws ssm put-parameter \
+            --name "/porth/${ENV}/auth-policy/index" \
+            --value "$INDEX" \
+            --type String \
+            --overwrite \
+            --region "$AWS_REGION" \
+            --no-cli-pager
+          echo "✅ /porth/${ENV}/auth-policy/index"
+
+          TEMPLATE_NAME="tenant-scoped-default"
+          TENANT_SESSION_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["dynamodb:GetItem","dynamodb:PutItem","dynamodb:Query","dynamodb:UpdateItem","dynamodb:DeleteItem","dynamodb:BatchGetItem","dynamodb:BatchWriteItem","dynamodb:ConditionCheckItem"],"Resource":"*","Condition":{"ForAllValues:StringLike":{"dynamodb:LeadingKeys":["TENANT#$tenant","ORG#$org_id"]}}}]}'
+          aws ssm put-parameter \
+            --name "/porth/${ENV}/auth-session-policy/${TEMPLATE_NAME}" \
+            --value "$TENANT_SESSION_POLICY" \
+            --type String \
+            --overwrite \
+            --region "$AWS_REGION" \
+            --no-cli-pager
+          echo "✅ /porth/${ENV}/auth-session-policy/${TEMPLATE_NAME}"
+
+          SESSION_INDEX="{\"roles\":{\"tenant\":\"porth-tenant-${ENV}\",\"platform_admin\":\"porth-platform-admin-${ENV}\"},\"context_rules\":[],\"paths\":{\"default\":\"${TEMPLATE_NAME}\"}}"
+          aws ssm put-parameter \
+            --name "/porth/${ENV}/auth-session-policy/index" \
+            --value "$SESSION_INDEX" \
+            --type String \
+            --overwrite \
+            --region "$AWS_REGION" \
+            --no-cli-pager
+          echo "✅ /porth/${ENV}/auth-session-policy/index"
 
       - name: Install porth-common
         run: pip install "git+https://${{ secrets.GH_PAT }}@github.com/dragoninex1le/Components.git"

--- a/.github/workflows/porth-install.yml
+++ b/.github/workflows/porth-install.yml
@@ -25,7 +25,7 @@ on:
       sar_version:
         description: 'Porth SAR app semantic version to install/upgrade to'
         required: true
-        default: '0.0.5'
+        default: '0.0.6'
       stack_name:
         description: 'CloudFormation stack name in EMS'
         required: false
@@ -60,7 +60,7 @@ env:
 
 jobs:
   install-or-upgrade:
-    name: Install or upgrade Porth ${{ inputs.sar_version || '0.0.5' }}
+    name: Install or upgrade Porth ${{ inputs.sar_version || '0.0.6' }}
     runs-on: ubuntu-latest
     environment: porth-install
     timeout-minutes: 30
@@ -80,7 +80,7 @@ jobs:
       # also works when triggered by the push shim (inputs are empty on push).
       - name: Resolve effective inputs
         run: |
-          echo "EFF_SAR_VERSION=${{ inputs.sar_version || '0.0.5' }}" >> "$GITHUB_ENV"
+          echo "EFF_SAR_VERSION=${{ inputs.sar_version || '0.0.6' }}" >> "$GITHUB_ENV"
           echo "EFF_STACK_NAME=${{ inputs.stack_name || 'serverlessrepo-porth-components' }}" >> "$GITHUB_ENV"
           echo "EFF_SAR_APP_ID=${{ inputs.sar_app_id || 'arn:aws:serverlessrepo:us-east-1:084847995635:applications/porth-user-management' }}" >> "$GITHUB_ENV"
           echo "EFF_ENV_NAME=${{ inputs.environment_name || 'dev' }}" >> "$GITHUB_ENV"
@@ -440,6 +440,85 @@ jobs:
             }" \
             --region "$AWS_REGION"
           echo "✅ Platform tenant IdP config updated (direct DynamoDB)"
+
+      # ── Seed SSM auth-policy + session-policy templates ─────────────────────
+      # Components deploy.yml seeds these after every deploy, but porth-install
+      # (SAR consume path) has no equivalent step.  Without these params the
+      # AuthorizerFunction cannot load its policy cache and authorised routes
+      # return 500.  continue-on-error: true so a missing SSM permission doesn't
+      # block the rest of the workflow; an operator can re-run just this step.
+      - name: Seed SSM auth-policy templates
+        continue-on-error: true
+        run: |
+          ENV="${{ env.EFF_ENV_NAME }}"
+          ALLOW_ALL='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"execute-api:Invoke","Resource":"*"}]}'
+          INDEX='{ "/organizations":"platform-admin-only", "/tenants":"tenant-scoped-rbac", "/users":"tenant-scoped-user", "/roles":"tenant-scoped-rbac", "/permissions":"tenant-scoped-rbac", "/claim-mapping-configs":"tenant-scoped-rbac", "/org-units":"tenant-scoped-rbac", "/provision":"tenant-scoped-user" }'
+
+          for NAME in \
+            "/porth/${ENV}/auth-policy/platform-admin-only:$ALLOW_ALL" \
+            "/porth/${ENV}/auth-policy/tenant-scoped-rbac:$ALLOW_ALL" \
+            "/porth/${ENV}/auth-policy/tenant-scoped-user:$ALLOW_ALL"
+          do
+            PARAM="${NAME%%:*}"
+            VALUE="${NAME#*:}"
+            aws ssm put-parameter \
+              --name "$PARAM" \
+              --value "$VALUE" \
+              --type String \
+              --overwrite \
+              --region "$AWS_REGION" \
+              --no-cli-pager
+            echo "✅ $PARAM"
+          done
+
+          aws ssm put-parameter \
+            --name "/porth/${ENV}/auth-policy/index" \
+            --value "$INDEX" \
+            --type String \
+            --overwrite \
+            --region "$AWS_REGION" \
+            --no-cli-pager
+          echo "✅ /porth/${ENV}/auth-policy/index"
+
+          TEMPLATE_NAME="tenant-scoped-default"
+          TENANT_SESSION_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["dynamodb:GetItem","dynamodb:PutItem","dynamodb:Query","dynamodb:UpdateItem","dynamodb:DeleteItem","dynamodb:BatchGetItem","dynamodb:BatchWriteItem","dynamodb:ConditionCheckItem"],"Resource":"*","Condition":{"ForAllValues:StringLike":{"dynamodb:LeadingKeys":["TENANT#$tenant","ORG#$org_id"]}}}]}'
+          aws ssm put-parameter \
+            --name "/porth/${ENV}/auth-session-policy/${TEMPLATE_NAME}" \
+            --value "$TENANT_SESSION_POLICY" \
+            --type String \
+            --overwrite \
+            --region "$AWS_REGION" \
+            --no-cli-pager
+          echo "✅ /porth/${ENV}/auth-session-policy/${TEMPLATE_NAME}"
+
+          SESSION_INDEX="{\"roles\":{\"tenant\":\"porth-tenant-${ENV}\",\"platform_admin\":\"porth-platform-admin-${ENV}\"},\"context_rules\":[],\"paths\":{\"default\":\"${TEMPLATE_NAME}\"}}"
+          aws ssm put-parameter \
+            --name "/porth/${ENV}/auth-session-policy/index" \
+            --value "$SESSION_INDEX" \
+            --type String \
+            --overwrite \
+            --region "$AWS_REGION" \
+            --no-cli-pager
+          echo "✅ /porth/${ENV}/auth-session-policy/index"
+
+          # Seed the auth-test-token SSM fallback. The AuthorizerFunction reads
+          # PORTH_AUTH_TEST_TOKEN env var first (set via CFN AuthTestToken param),
+          # then falls back to this SSM path on cold start. Seeding here ensures the
+          # bypass works even when the CFN parameter was absent during the last deploy.
+          # Uses SecureString so the value is encrypted at rest.
+          AUTH_TEST_TOKEN="${{ secrets.PORTH_AUTH_TEST_TOKEN }}"
+          if [ -n "$AUTH_TEST_TOKEN" ]; then
+            aws ssm put-parameter \
+              --name "/porth/${ENV}/auth-test-token" \
+              --value "$AUTH_TEST_TOKEN" \
+              --type SecureString \
+              --overwrite \
+              --region "$AWS_REGION" \
+              --no-cli-pager
+            echo "✅ /porth/${ENV}/auth-test-token"
+          else
+            echo "⚠️  PORTH_AUTH_TEST_TOKEN secret not set — skipping auth-test-token SSM seed"
+          fi
 
       - name: Smoke test Porth API
         run: |


### PR DESCRIPTION
Replaces #48 (which had merge conflicts after main moved significantly).

## Changes

### `bootstrap.yml`
- Add `stack_name` workflow_dispatch input (default: `serverlessrepo-porth-components`)
- Fix hardcoded `STACK=porth-components` → `serverlessrepo-porth-components`
- Add SSM auth-policy and session-policy seeding (required by AuthorizerFunction policy cache)

### `porth-install.yml`
- Bump SAR default version `0.0.5` → `0.0.6` — fixes `Runtime.ImportModuleError: No module named 'jwt'`
- Two-step SAR consume: render-template + `cloudformation create-change-set` with CFN execution role
- Pass `AuthTestToken` from `PORTH_AUTH_TEST_TOKEN` secret
- Platform IdP patch: switch from API call → direct DynamoDB write (removes EventBridge dependency)
- Add SSM auth-policy template seeding for EMS account
- Add Route 53 alias upsert for Porth API custom domain
- Fix all stack name references

### `deploy.yml`
No change — already fixed via `vars.PORTH_STACK_NAME || 'serverlessrepo-porth-components'`

## Deploy sequence after merge
1. EMS `deploy.yml` CI runs → frontend builds with correct `VITE_API_BASE_URL`
2. Once Components CI publishes SAR v0.0.6: trigger `porth-install` manually → Lambda upgraded
3. `GET /tenants/platform` returns 200 → EMS login works