### PR TITLE
fix(porth): env-scope the platform tenant + neutral OIDC — unblocks login (PORTH-532)

### DIFF
--- a/.github/workflows/porth-install.yml
+++ b/.github/workflows/porth-install.yml
@@ -571,9 +571,12 @@ jobs:
           PORTH_PERMISSIONS_TABLE: ${{ env.PORTH_PERMISSIONS_TABLE }}
           PORTH_ROLES_TABLE: ${{ env.PORTH_ROLES_TABLE }}
           PORTH_CLAIM_MAPPING_CONFIGS_TABLE: ${{ env.PORTH_CLAIM_MAPPING_CONFIGS_TABLE }}
+          # ADR-Z8 (PORTH-532): the install pins FixedEnvironment, so the bootstrap must
+          # write ENV#{scope}#… or the authorizer will never resolve the platform tenant.
+          PORTH_ENV_SCOPE: ${{ env.EFF_FIXED_ENV }}
         run: |
           python3 scripts/bootstrap_platform_tenant.py
-          echo "✅ Platform tenant bootstrapped"
+          echo "✅ Platform tenant bootstrapped under ENV#${EFF_FIXED_ENV}#"
 
       - name: Patch platform tenant IdP config (direct DynamoDB)
         # Writes idp_config_override directly to DynamoDB — same pattern as the
@@ -596,21 +599,31 @@ jobs:
           CLIENT_ID="${{ secrets.PLATFORM_AUTH0_CLIENT_ID }}"
           NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          echo "Writing idp_config_override to DynamoDB (domain=${DOMAIN} audience-len=${#AUDIENCE})"
+          # PORTH-488: 0.1.16 resolves tenants on a NEUTRAL OIDC config (issuer + jwks_uri),
+          # not the legacy Auth0 {domain, client_id} pair. PORTH-514: the record must sit at
+          # the env-scoped key the authorizer actually reads.
+          ISSUER="https://${DOMAIN}/"
+          JWKS_URI="https://${DOMAIN}/.well-known/jwks.json"
+          PLATFORM_PK="ENV#${EFF_FIXED_ENV}#TENANT#platform"
+
+          echo "Writing neutral idp_config_override (pk=${PLATFORM_PK} issuer=${ISSUER} audience-len=${#AUDIENCE})"
           aws dynamodb update-item \
             --table-name "$PORTH_TENANTS_TABLE" \
-            --key '{"PK":{"S":"TENANT#platform"},"SK":{"S":"METADATA"}}' \
-            --update-expression "SET idp_config_override = :idp, updated_at = :ua" \
+            --key "{\"PK\":{\"S\":\"${PLATFORM_PK}\"},\"SK\":{\"S\":\"METADATA\"}}" \
+            --update-expression "SET idp_config_override = :idp, tenant_tier = :tier, updated_at = :ua" \
             --expression-attribute-values "{
               \":idp\":{\"M\":{
-                \"domain\":{\"S\":\"${DOMAIN}\"},
+                \"issuer\":{\"S\":\"${ISSUER}\"},
+                \"jwks_uri\":{\"S\":\"${JWKS_URI}\"},
                 \"client_id\":{\"S\":\"${CLIENT_ID}\"},
-                \"audience\":{\"S\":\"${AUDIENCE}\"}
+                \"audience\":{\"S\":\"${AUDIENCE}\"},
+                \"protocol\":{\"S\":\"auth0\"}
               }},
+              \":tier\":{\"S\":\"production\"},
               \":ua\":{\"S\":\"${NOW}\"}
             }" \
             --region "$AWS_REGION"
-          echo "✅ Platform tenant IdP config updated (direct DynamoDB)"
+          echo "✅ Platform tenant IdP config + tenant_tier updated (direct DynamoDB)"
 
       # ── Seed SSM auth-policy + session-policy templates ─────────────────────
       # Components deploy.yml seeds these after every deploy, but porth-install

--- a/.github/workflows/reset-env.yml
+++ b/.github/workflows/reset-env.yml
@@ -2,15 +2,39 @@ name: Reset Dev Environment
 
 # Clears all tenant data from DynamoDB, re-bootstraps the platform tenant,
 # and patches the platform IdP config.  Use this to get back to a clean
-# known state before running Tier 2 E2E tests.
+# known state before running Tier 2 E2E tests, or before re-seeding test
+# tenants with porth-seed-testbed.
 #
 # No porth-common dependency — bootstrap is done with raw boto3 DynamoDB
 # calls so this workflow works without a GH_PAT that can read Components.
+#
+# PORTH-532 — brought up to SAR 0.1.16:
+#   * stack name is serverlessrepo-porth-components (SAR console install name)
+#   * porth-sessions-* is cleaned too (ADR-Z9 BFF session spine)
+#   * every partition key is written env-scoped as ENV#{env_scope}#… (ADR-Z8).
+#     The install runs EnvironmentMode=single / FixedEnvironment=prod, so the
+#     authorizer resolves ENV#prod#TENANT#platform — an unscoped record is
+#     invisible to it (PORTH-514).
+#   * idp_config_override uses neutral OIDC (issuer + jwks_uri), not the legacy
+#     Auth0 {domain, client_id} shape (PORTH-488)
+#   * tenant_tier replaces environment_type (PORTH-502)
 #
 # Trigger:  Actions → Reset Dev Environment → Run workflow
 
 on:
   workflow_dispatch:
+    inputs:
+      env_scope:
+        description: >
+          ADR-Z8 environment slot to write under (ENV#{scope}#…). Must match the
+          Porth install's FixedEnvironment, or the authorizer will not find these
+          records. DATA axis — not the table-name suffix.
+        required: false
+        default: 'prod'
+      stack_name:
+        description: 'Porth components CloudFormation stack name'
+        required: false
+        default: 'serverlessrepo-porth-components'
 
 concurrency:
   group: reset-dev-env
@@ -22,11 +46,14 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
+  ENV_SCOPE: ${{ inputs.env_scope || 'prod' }}
+  PORTH_STACK: ${{ inputs.stack_name || 'serverlessrepo-porth-components' }}
 
 jobs:
   reset:
     name: Reset Dev Environment
     runs-on: ubuntu-latest
+    environment: porth-install
 
     steps:
       - uses: actions/checkout@v4
@@ -42,47 +69,83 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Resolve stack outputs
         run: |
+          set -euo pipefail
           get_porth() {
             aws cloudformation describe-stacks \
-              --stack-name porth-components \
+              --stack-name "$PORTH_STACK" \
               --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" \
-              --output text
+              --output text 2>/dev/null || echo ""
           }
           CLEANUP_FN=$(aws cloudformation describe-stacks \
             --stack-name porth-qa-tools \
             --query "Stacks[0].Outputs[?OutputKey=='QaCleanupFunctionArn'].OutputValue" \
             --output text)
-          echo "PORTH_API_URL=$(get_porth PorthApiUrl)"                                       >> $GITHUB_ENV
-          echo "PORTH_TENANTS_TABLE=$(get_porth TenantsTableName)"                            >> $GITHUB_ENV
-          echo "PORTH_PERMISSIONS_TABLE=$(get_porth PermissionsTableName)"                    >> $GITHUB_ENV
-          echo "PORTH_ROLES_TABLE=$(get_porth RolesTableName)"                                >> $GITHUB_ENV
-          echo "PORTH_CLAIM_MAPPING_CONFIGS_TABLE=$(get_porth ClaimMappingConfigsTableName)"  >> $GITHUB_ENV
-          echo "CLEANUP_FN=$CLEANUP_FN"                                                        >> $GITHUB_ENV
+
+          PORTH_API_URL=$(get_porth PorthApiUrl)
+          TENANTS_TABLE=$(get_porth TenantsTableName)
+          PERMISSIONS_TABLE=$(get_porth PermissionsTableName)
+          ROLES_TABLE=$(get_porth RolesTableName)
+          CLAIM_TABLE=$(get_porth ClaimMappingConfigsTableName)
+          SESSIONS_TABLE=$(get_porth SessionsTableName)
+
+          # Fail loudly rather than silently no-op on an empty lookup — the whole
+          # reason this workflow was broken is that a wrong stack name returned "".
+          MISSING=""
+          for pair in "TenantsTableName:$TENANTS_TABLE" "PermissionsTableName:$PERMISSIONS_TABLE" \
+                      "RolesTableName:$ROLES_TABLE" "ClaimMappingConfigsTableName:$CLAIM_TABLE"; do
+            name="${pair%%:*}"; val="${pair#*:}"
+            if [ -z "$val" ] || [ "$val" = "None" ]; then MISSING="$MISSING $name"; fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::Stack '$PORTH_STACK' is missing expected outputs:$MISSING"
+            exit 1
+          fi
+
+          echo "PORTH_API_URL=$PORTH_API_URL"                                    >> $GITHUB_ENV
+          echo "PORTH_TENANTS_TABLE=$TENANTS_TABLE"                              >> $GITHUB_ENV
+          echo "PORTH_PERMISSIONS_TABLE=$PERMISSIONS_TABLE"                      >> $GITHUB_ENV
+          echo "PORTH_ROLES_TABLE=$ROLES_TABLE"                                  >> $GITHUB_ENV
+          echo "PORTH_CLAIM_MAPPING_CONFIGS_TABLE=$CLAIM_TABLE"                  >> $GITHUB_ENV
+          echo "PORTH_SESSIONS_TABLE=$SESSIONS_TABLE"                            >> $GITHUB_ENV
+          echo "CLEANUP_FN=$CLEANUP_FN"                                          >> $GITHUB_ENV
+          echo "✅ Resolved outputs from $PORTH_STACK (sessions: ${SESSIONS_TABLE:-<absent>})"
 
       - name: Cleanup all tenant data
         run: |
           python3 - <<'EOF'
-          import boto3, json, sys, os
+          import boto3, json, os, sys
 
-          TABLES = [
-              "porth-users-dev",
-              "porth-tenants-dev",
-              "porth-permissions-dev",
-              "porth-roles-dev",
-              "porth-claim-mapping-configs-dev",
-              "porth-org-units-dev",
+          # Table list is derived from the stack outputs where possible so a rename
+          # can't silently leave a table uncleaned. porth-users/org-units have no
+          # outputs, so they stay name-derived from the tenants table's suffix.
+          tenants = os.environ["PORTH_TENANTS_TABLE"]
+          suffix = tenants.rsplit("-", 1)[-1]  # e.g. "dev"
+
+          tables = [
+              f"porth-users-{suffix}",
+              tenants,
+              os.environ["PORTH_PERMISSIONS_TABLE"],
+              os.environ["PORTH_ROLES_TABLE"],
+              os.environ["PORTH_CLAIM_MAPPING_CONFIGS_TABLE"],
+              f"porth-org-units-{suffix}",
           ]
+          # PORTH-532: the ADR-Z9 BFF session spine. Omitting it left live sessions
+          # across a "full" reset.
+          sessions = os.environ.get("PORTH_SESSIONS_TABLE", "")
+          if sessions and sessions != "None":
+              tables.append(sessions)
+
           fn = os.environ["CLEANUP_FN"]
           client = boto3.client("lambda", region_name="us-east-1")
           failed = False
 
-          print("Cleaning all tables...")
-          for table in TABLES:
+          print(f"Cleaning {len(tables)} tables...")
+          for table in tables:
               payload = {"body": json.dumps({"table_name": table})}
               resp = client.invoke(FunctionName=fn, Payload=json.dumps(payload))
               result = json.loads(resp["Payload"].read())
@@ -104,49 +167,56 @@ jobs:
           PORTH_CLAIM_MAPPING_CONFIGS_TABLE: ${{ env.PORTH_CLAIM_MAPPING_CONFIGS_TABLE }}
         run: |
           python3 - <<'PYEOF'
-          import boto3, json, os, uuid, hashlib
+          import boto3, os, uuid
           from datetime import datetime, timezone
           from boto3.dynamodb.conditions import Key
 
           def utc_now():
               return datetime.now(timezone.utc).isoformat()
 
+          ENV_SCOPE = os.environ["ENV_SCOPE"]
+
+          def env_key(base: str) -> str:
+              """ADR-Z8: fold the environment into the CONTENT of the partition key, never the
+              KeySchema. Applied to PK/pk and gsi1pk only — never to sort keys, because
+              environment is an outer partition axis."""
+              return f"ENV#{ENV_SCOPE}#{base}" if ENV_SCOPE else base
+
           dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
-          TENANTS_TABLE     = os.environ["PORTH_TENANTS_TABLE"]
-          PERMISSIONS_TABLE = os.environ["PORTH_PERMISSIONS_TABLE"]
-          ROLES_TABLE       = os.environ["PORTH_ROLES_TABLE"]
-          CLAIM_TABLE       = os.environ["PORTH_CLAIM_MAPPING_CONFIGS_TABLE"]
-
-          tenants_tbl  = dynamodb.Table(TENANTS_TABLE)
-          perms_tbl    = dynamodb.Table(PERMISSIONS_TABLE)
-          roles_tbl    = dynamodb.Table(ROLES_TABLE)
-          claim_tbl    = dynamodb.Table(CLAIM_TABLE)
+          tenants_tbl = dynamodb.Table(os.environ["PORTH_TENANTS_TABLE"])
+          perms_tbl   = dynamodb.Table(os.environ["PORTH_PERMISSIONS_TABLE"])
+          roles_tbl   = dynamodb.Table(os.environ["PORTH_ROLES_TABLE"])
+          claim_tbl   = dynamodb.Table(os.environ["PORTH_CLAIM_MAPPING_CONFIGS_TABLE"])
 
           now = utc_now()
+          PLATFORM_PK = env_key("TENANT#platform")
+          print(f"Bootstrapping platform tenant under ENV_SCOPE={ENV_SCOPE!r} (PK={PLATFORM_PK})")
 
           # ── 0. Platform org + tenant ─────────────────────────────────────────
           print("\n0. Platform org + tenant")
-          existing = tenants_tbl.get_item(Key={"PK": "TENANT#platform", "SK": "METADATA"})
+          existing = tenants_tbl.get_item(Key={"PK": PLATFORM_PK, "SK": "METADATA"})
           if "Item" in existing:
               org_id = existing["Item"]["org_id"]
-              print(f"    exists   TENANT#platform (org_id={org_id})")
+              print(f"    exists   {PLATFORM_PK} (org_id={org_id})")
           else:
               org_id = str(uuid.uuid4())
               tenants_tbl.put_item(Item={
-                  "PK": f"ORG#{org_id}", "SK": "METADATA",
-                  "gsi1pk": "ORG_SLUG#platform", "gsi1sk": "METADATA",
+                  "PK": env_key(f"ORG#{org_id}"), "SK": "METADATA",
+                  "gsi1pk": env_key("ORG_SLUG#platform"), "gsi1sk": "METADATA",
                   "id": org_id, "name": "Platform", "slug": "platform",
                   "status": "active", "created_at": now, "updated_at": now,
               })
               tenants_tbl.put_item(Item={
-                  "PK": "TENANT#platform", "SK": "METADATA",
-                  "gsi1pk": f"ORG#{org_id}", "gsi1sk": "TENANT#platform",
+                  "PK": PLATFORM_PK, "SK": "METADATA",
+                  "gsi1pk": env_key(f"ORG#{org_id}"), "gsi1sk": "TENANT#platform",
                   "tenant_id": "platform", "org_id": org_id, "org_name": "Platform",
-                  "display_name": "Platform", "environment_type": "production",
+                  "display_name": "Platform",
+                  # PORTH-502: environment_type was renamed tenant_tier.
+                  "tenant_tier": "production",
                   "status": "active", "created_at": now, "updated_at": now,
               })
-              print(f"    created  ORG#{org_id} + TENANT#platform")
+              print(f"    created  ORG#{org_id} + {PLATFORM_PK}")
 
           # ── 1. Platform permissions ──────────────────────────────────────────
           print("\n1. Permissions")
@@ -166,29 +236,29 @@ jobs:
           permission_keys = []
           for p in PERMISSIONS:
               perms_tbl.put_item(Item={
-                  "pk": f"TENANT#platform#NS#{APP_NS}", "sk": f"PERM#{p['key']}",
-                  "gsi1pk": "TENANT#platform", "gsi1sk": f"CAT#{p['category']}#PERM#{p['key']}",
+                  "pk": env_key(f"TENANT#platform#NS#{APP_NS}"), "sk": f"PERM#{p['key']}",
+                  "gsi1pk": PLATFORM_PK, "gsi1sk": f"CAT#{p['category']}#PERM#{p['key']}",
                   "id": str(uuid.uuid4()), "key": p["key"], "display_name": p["display_name"],
                   "category": p["category"], "app_namespace": APP_NS,
                   "tenant_id": "platform", "sort_order": p["sort_order"],
                   "created_at": now, "updated_at": now,
               })
               permission_keys.append(p["key"])
-              print(f"    registered  {p['key']}")
+          print(f"    registered {len(permission_keys)} permissions")
 
           # ── 2. platform-admin role ───────────────────────────────────────────
           print("\n2. platform-admin role")
           resp = roles_tbl.query(
-              KeyConditionExpression=Key("pk").eq("TENANT#platform") & Key("sk").begins_with("ROLE#")
+              KeyConditionExpression=Key("pk").eq(PLATFORM_PK) & Key("sk").begins_with("ROLE#")
           )
           role_id = None
           for item in resp.get("Items", []):
               if item.get("name") == "platform-admin":
                   role_id = item["id"]
-                  # Ensure source_key is set correctly
+                  # source_key is what the claim mapping resolves the IdP role claim against.
                   if item.get("source_key") != "platform-admin":
                       roles_tbl.update_item(
-                          Key={"pk": "TENANT#platform", "sk": f"ROLE#{role_id}"},
+                          Key={"pk": PLATFORM_PK, "sk": f"ROLE#{role_id}"},
                           UpdateExpression="SET source_key = :sk, updated_at = :ua",
                           ExpressionAttributeValues={":sk": "platform-admin", ":ua": now},
                       )
@@ -200,7 +270,7 @@ jobs:
           if not role_id:
               role_id = str(uuid.uuid4())
               roles_tbl.put_item(Item={
-                  "pk": "TENANT#platform", "sk": f"ROLE#{role_id}",
+                  "pk": PLATFORM_PK, "sk": f"ROLE#{role_id}",
                   "id": role_id, "tenant_id": "platform", "name": "platform-admin",
                   "is_system": True, "source_key": "platform-admin",
                   "description": "System role for platform-level tenant administration",
@@ -210,16 +280,15 @@ jobs:
 
           # ── 3. Role–permission links ─────────────────────────────────────────
           print("\n3. Role–permission links")
-          # Remove old links
+          ROLE_PK = env_key(f"ROLE#{role_id}")
           old = roles_tbl.query(
-              KeyConditionExpression=Key("pk").eq(f"ROLE#{role_id}") & Key("sk").begins_with("PERM#")
+              KeyConditionExpression=Key("pk").eq(ROLE_PK) & Key("sk").begins_with("PERM#")
           )
           for item in old.get("Items", []):
               roles_tbl.delete_item(Key={"pk": item["pk"], "sk": item["sk"]})
-          # Write new links
           for pkey in permission_keys:
               roles_tbl.put_item(Item={
-                  "pk": f"ROLE#{role_id}", "sk": f"PERM#{pkey}",
+                  "pk": ROLE_PK, "sk": f"PERM#{pkey}",
                   "role_id": role_id, "permission_key": pkey,
                   "tenant_id": "platform", "assigned_at": now,
               })
@@ -234,7 +303,6 @@ jobs:
                           "ops": [{"op": "resolve_roles"}]}],
               "default_roles": [],
           }
-          # compiled_source pre-generated by MappingCodegen.generate(MAPPING_SOURCE)
           COMPILED_SOURCE = (
               "# AUTO-GENERATED by claim_mapping_codegen — config hash c9845fb83254fbc8\n"
               "# DO NOT EDIT manually. Re-generate from the mapping config.\n"
@@ -292,7 +360,7 @@ jobs:
           COMPILED_HASH = "55016a468cbb18927879e32725927fc3d501a7887918f05eed50911918fd6855"
 
           existing_cfg = claim_tbl.query(
-              KeyConditionExpression=Key("PK").eq("TENANT#platform"),
+              KeyConditionExpression=Key("PK").eq(PLATFORM_PK),
               ScanIndexForward=False, Limit=1,
           )
           if existing_cfg.get("Items"):
@@ -302,8 +370,8 @@ jobs:
               else:
                   version = latest["version"] + 1
                   claim_tbl.put_item(Item={
-                      "PK": "TENANT#platform", "SK": f"VERSION#{version:06d}",
-                      "gsi1pk": "TENANT#platform", "gsi1sk": f"VERSION#{version:06d}",
+                      "PK": PLATFORM_PK, "SK": f"VERSION#{version:06d}",
+                      "gsi1pk": PLATFORM_PK, "gsi1sk": f"VERSION#{version:06d}",
                       "id": str(uuid.uuid4()), "tenant_id": "platform", "version": version,
                       "mapping_source": MAPPING_SOURCE, "compiled_source": COMPILED_SOURCE,
                       "compiled_hash": COMPILED_HASH,
@@ -312,8 +380,8 @@ jobs:
                   print(f"    saved    claim mapping config v{version}")
           else:
               claim_tbl.put_item(Item={
-                  "PK": "TENANT#platform", "SK": "VERSION#000001",
-                  "gsi1pk": "TENANT#platform", "gsi1sk": "VERSION#000001",
+                  "PK": PLATFORM_PK, "SK": "VERSION#000001",
+                  "gsi1pk": PLATFORM_PK, "gsi1sk": "VERSION#000001",
                   "id": str(uuid.uuid4()), "tenant_id": "platform", "version": 1,
                   "mapping_source": MAPPING_SOURCE, "compiled_source": COMPILED_SOURCE,
                   "compiled_hash": COMPILED_HASH,
@@ -324,42 +392,64 @@ jobs:
           print("\n✅ Platform tenant bootstrap complete")
           PYEOF
 
-      - name: Patch platform tenant IdP config
+      - name: Patch platform tenant IdP config (direct DynamoDB)
+        # PORTH-532: was `PATCH /tenants/platform` with a retry loop. That is
+        # chicken-and-egg during a reset — the API needs a working authorizer,
+        # which is exactly what a missing/misscoped platform tenant prevents.
+        # Writing DynamoDB directly is what porth-install already does.
         env:
           PORTH_TENANT_CONFIG: ${{ secrets.PORTH_TENANT_CONFIG }}
         run: |
-          TEST_TOKEN="${{ secrets.PORTH_AUTH_TEST_TOKEN }}"
-          RESPONSE_FILE="/tmp/patch-tenant.json"
-
+          set -euo pipefail
           AUDIENCE=$(echo "$PORTH_TENANT_CONFIG" | python3 -c \
-            "import json,sys; raw=sys.stdin.read().strip(); d=json.loads(raw); d=d if isinstance(d,dict) else json.loads(d); print(d.get('audience',''),end='')" \
+            "import json,sys; raw=sys.stdin.read().strip(); d=json.loads(raw) if raw else {}; d=d if isinstance(d,dict) else json.loads(d); print(d.get('audience',''),end='')" \
             2>/dev/null || true)
           if [ -z "$AUDIENCE" ]; then
             AUDIENCE="${{ secrets.PLATFORM_AUTH0_AUDIENCE }}"
           fi
+          DOMAIN="${{ secrets.PLATFORM_AUTH0_DOMAIN }}"
+          CLIENT_ID="${{ secrets.PLATFORM_AUTH0_CLIENT_ID }}"
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          PAYLOAD="{\"idp_config_override\":{\"domain\":\"${{ secrets.PLATFORM_AUTH0_DOMAIN }}\",\"client_id\":\"${{ secrets.PLATFORM_AUTH0_CLIENT_ID }}\",\"audience\":\"${AUDIENCE}\"}}"
+          if [ -z "$DOMAIN" ]; then
+            echo "::warning::PLATFORM_AUTH0_DOMAIN not set — skipping IdP config patch"
+            exit 0
+          fi
 
-          for attempt in 1 2 3 4 5; do
-            STATUS=$(curl -s -o "$RESPONSE_FILE" -w "%{http_code}" \
-              -X PATCH "${{ env.PORTH_API_URL }}/tenants/platform" \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer $TEST_TOKEN" \
-              -d "$PAYLOAD")
-            echo "Attempt $attempt: PATCH /tenants/platform → HTTP $STATUS"
-            if [[ "$STATUS" == "200" ]]; then
-              echo "✅ Platform tenant IdP config updated"
-              break
-            fi
-            echo "Response: $(cat $RESPONSE_FILE)"
-            if [[ $attempt -lt 5 ]]; then
-              echo "Retrying in 5s..."
-              sleep 5
-            else
-              echo "❌ Failed to patch platform tenant IdP config after $attempt attempts"
-              exit 1
-            fi
-          done
+          # PORTH-488: SAR 0.1.16 resolves tenants on a NEUTRAL OIDC config —
+          # issuer + jwks_uri — not the legacy Auth0 {domain, client_id} pair.
+          ISSUER="https://${DOMAIN}/"
+          JWKS_URI="https://${DOMAIN}/.well-known/jwks.json"
+          PLATFORM_PK="ENV#${ENV_SCOPE}#TENANT#platform"
+
+          echo "Writing neutral idp_config_override (pk=${PLATFORM_PK} issuer=${ISSUER} audience-len=${#AUDIENCE})"
+          aws dynamodb update-item \
+            --table-name "$PORTH_TENANTS_TABLE" \
+            --key "{\"PK\":{\"S\":\"${PLATFORM_PK}\"},\"SK\":{\"S\":\"METADATA\"}}" \
+            --update-expression "SET idp_config_override = :idp, tenant_tier = :tier, updated_at = :ua" \
+            --expression-attribute-values "{
+              \":idp\":{\"M\":{
+                \"issuer\":{\"S\":\"${ISSUER}\"},
+                \"jwks_uri\":{\"S\":\"${JWKS_URI}\"},
+                \"client_id\":{\"S\":\"${CLIENT_ID}\"},
+                \"audience\":{\"S\":\"${AUDIENCE}\"},
+                \"protocol\":{\"S\":\"auth0\"}
+              }},
+              \":tier\":{\"S\":\"production\"},
+              \":ua\":{\"S\":\"${NOW}\"}
+            }" \
+            --region "$AWS_REGION"
+          echo "✅ Platform tenant IdP config + tenant_tier updated (direct DynamoDB)"
 
       - name: Done
-        run: echo "✅ Dev environment reset complete — platform tenant only, ready for E2E tests"
+        run: |
+          {
+            echo "## Reset complete"
+            echo ""
+            echo "- **Stack:** ${PORTH_STACK}"
+            echo "- **Env scope:** \`${ENV_SCOPE}\` (records at \`ENV#${ENV_SCOPE}#…\`)"
+            echo "- **State:** platform tenant only"
+            echo ""
+            echo "Next: run **porth-seed-testbed** to add the synthetic test tenants,"
+            echo "then Tier 2 E2E (it creates its own \`demo-tenant\`)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reset-env.yml
+++ b/.github/workflows/reset-env.yml
@@ -5,19 +5,17 @@ name: Reset Dev Environment
 # known state before running Tier 2 E2E tests, or before re-seeding test
 # tenants with porth-seed-testbed.
 #
-# No porth-common dependency — bootstrap is done with raw boto3 DynamoDB
-# calls so this workflow works without a GH_PAT that can read Components.
-#
 # PORTH-532 — brought up to SAR 0.1.16:
 #   * stack name is serverlessrepo-porth-components (SAR console install name)
 #   * porth-sessions-* is cleaned too (ADR-Z9 BFF session spine)
-#   * every partition key is written env-scoped as ENV#{env_scope}#… (ADR-Z8).
-#     The install runs EnvironmentMode=single / FixedEnvironment=prod, so the
+#   * the platform bootstrap runs env-scoped via PORTH_ENV_SCOPE (ADR-Z8). The
+#     install runs EnvironmentMode=single / FixedEnvironment=prod, so the
 #     authorizer resolves ENV#prod#TENANT#platform — an unscoped record is
 #     invisible to it (PORTH-514).
 #   * idp_config_override uses neutral OIDC (issuer + jwks_uri), not the legacy
 #     Auth0 {domain, client_id} shape (PORTH-488)
-#   * tenant_tier replaces environment_type (PORTH-502)
+#   * the bootstrap is the shared scripts/bootstrap_platform_tenant.py rather than
+#     an inline copy, so the scoping fix cannot drift between workflows
 #
 # Trigger:  Actions → Reset Dev Environment → Run workflow
 
@@ -159,238 +157,18 @@ jobs:
           sys.exit(1 if failed else 0)
           EOF
 
-      - name: Bootstrap platform tenant (raw boto3 — no porth-common required)
+      # Shared with porth-install.yml — one implementation, so the ADR-Z8 scoping
+      # cannot drift between the install path and the reset path.
+      - name: Bootstrap platform tenant
         env:
           PORTH_TENANTS_TABLE: ${{ env.PORTH_TENANTS_TABLE }}
           PORTH_PERMISSIONS_TABLE: ${{ env.PORTH_PERMISSIONS_TABLE }}
           PORTH_ROLES_TABLE: ${{ env.PORTH_ROLES_TABLE }}
           PORTH_CLAIM_MAPPING_CONFIGS_TABLE: ${{ env.PORTH_CLAIM_MAPPING_CONFIGS_TABLE }}
+          PORTH_ENV_SCOPE: ${{ env.ENV_SCOPE }}
         run: |
-          python3 - <<'PYEOF'
-          import boto3, os, uuid
-          from datetime import datetime, timezone
-          from boto3.dynamodb.conditions import Key
-
-          def utc_now():
-              return datetime.now(timezone.utc).isoformat()
-
-          ENV_SCOPE = os.environ["ENV_SCOPE"]
-
-          def env_key(base: str) -> str:
-              """ADR-Z8: fold the environment into the CONTENT of the partition key, never the
-              KeySchema. Applied to PK/pk and gsi1pk only — never to sort keys, because
-              environment is an outer partition axis."""
-              return f"ENV#{ENV_SCOPE}#{base}" if ENV_SCOPE else base
-
-          dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-
-          tenants_tbl = dynamodb.Table(os.environ["PORTH_TENANTS_TABLE"])
-          perms_tbl   = dynamodb.Table(os.environ["PORTH_PERMISSIONS_TABLE"])
-          roles_tbl   = dynamodb.Table(os.environ["PORTH_ROLES_TABLE"])
-          claim_tbl   = dynamodb.Table(os.environ["PORTH_CLAIM_MAPPING_CONFIGS_TABLE"])
-
-          now = utc_now()
-          PLATFORM_PK = env_key("TENANT#platform")
-          print(f"Bootstrapping platform tenant under ENV_SCOPE={ENV_SCOPE!r} (PK={PLATFORM_PK})")
-
-          # ── 0. Platform org + tenant ─────────────────────────────────────────
-          print("\n0. Platform org + tenant")
-          existing = tenants_tbl.get_item(Key={"PK": PLATFORM_PK, "SK": "METADATA"})
-          if "Item" in existing:
-              org_id = existing["Item"]["org_id"]
-              print(f"    exists   {PLATFORM_PK} (org_id={org_id})")
-          else:
-              org_id = str(uuid.uuid4())
-              tenants_tbl.put_item(Item={
-                  "PK": env_key(f"ORG#{org_id}"), "SK": "METADATA",
-                  "gsi1pk": env_key("ORG_SLUG#platform"), "gsi1sk": "METADATA",
-                  "id": org_id, "name": "Platform", "slug": "platform",
-                  "status": "active", "created_at": now, "updated_at": now,
-              })
-              tenants_tbl.put_item(Item={
-                  "PK": PLATFORM_PK, "SK": "METADATA",
-                  "gsi1pk": env_key(f"ORG#{org_id}"), "gsi1sk": "TENANT#platform",
-                  "tenant_id": "platform", "org_id": org_id, "org_name": "Platform",
-                  "display_name": "Platform",
-                  # PORTH-502: environment_type was renamed tenant_tier.
-                  "tenant_tier": "production",
-                  "status": "active", "created_at": now, "updated_at": now,
-              })
-              print(f"    created  ORG#{org_id} + {PLATFORM_PK}")
-
-          # ── 1. Platform permissions ──────────────────────────────────────────
-          print("\n1. Permissions")
-          APP_NS = "porth-platform"
-          PERMISSIONS = [
-              {"key": "platform.tenants.read",    "display_name": "View Tenants",           "category": "Tenants",       "sort_order": 10},
-              {"key": "platform.tenants.create",   "display_name": "Create Tenants",         "category": "Tenants",       "sort_order": 20},
-              {"key": "platform.tenants.update",   "display_name": "Update Tenants",         "category": "Tenants",       "sort_order": 30},
-              {"key": "platform.tenants.delete",   "display_name": "Delete Tenants",         "category": "Tenants",       "sort_order": 40},
-              {"key": "platform.orgs.read",        "display_name": "View Organisations",     "category": "Organisations", "sort_order": 10},
-              {"key": "platform.orgs.create",      "display_name": "Create Organisations",   "category": "Organisations", "sort_order": 20},
-              {"key": "platform.orgs.update",      "display_name": "Update Organisations",   "category": "Organisations", "sort_order": 30},
-              {"key": "platform.orgs.delete",      "display_name": "Delete Organisations",   "category": "Organisations", "sort_order": 40},
-              {"key": "platform.settings.read",    "display_name": "View Platform Settings", "category": "Settings",      "sort_order": 10},
-              {"key": "platform.settings.write",   "display_name": "Edit Platform Settings", "category": "Settings",      "sort_order": 20},
-          ]
-          permission_keys = []
-          for p in PERMISSIONS:
-              perms_tbl.put_item(Item={
-                  "pk": env_key(f"TENANT#platform#NS#{APP_NS}"), "sk": f"PERM#{p['key']}",
-                  "gsi1pk": PLATFORM_PK, "gsi1sk": f"CAT#{p['category']}#PERM#{p['key']}",
-                  "id": str(uuid.uuid4()), "key": p["key"], "display_name": p["display_name"],
-                  "category": p["category"], "app_namespace": APP_NS,
-                  "tenant_id": "platform", "sort_order": p["sort_order"],
-                  "created_at": now, "updated_at": now,
-              })
-              permission_keys.append(p["key"])
-          print(f"    registered {len(permission_keys)} permissions")
-
-          # ── 2. platform-admin role ───────────────────────────────────────────
-          print("\n2. platform-admin role")
-          resp = roles_tbl.query(
-              KeyConditionExpression=Key("pk").eq(PLATFORM_PK) & Key("sk").begins_with("ROLE#")
-          )
-          role_id = None
-          for item in resp.get("Items", []):
-              if item.get("name") == "platform-admin":
-                  role_id = item["id"]
-                  # source_key is what the claim mapping resolves the IdP role claim against.
-                  if item.get("source_key") != "platform-admin":
-                      roles_tbl.update_item(
-                          Key={"pk": PLATFORM_PK, "sk": f"ROLE#{role_id}"},
-                          UpdateExpression="SET source_key = :sk, updated_at = :ua",
-                          ExpressionAttributeValues={":sk": "platform-admin", ":ua": now},
-                      )
-                      print(f"    patched  source_key → platform-admin (id={role_id})")
-                  else:
-                      print(f"    exists   platform-admin (id={role_id})")
-                  break
-
-          if not role_id:
-              role_id = str(uuid.uuid4())
-              roles_tbl.put_item(Item={
-                  "pk": PLATFORM_PK, "sk": f"ROLE#{role_id}",
-                  "id": role_id, "tenant_id": "platform", "name": "platform-admin",
-                  "is_system": True, "source_key": "platform-admin",
-                  "description": "System role for platform-level tenant administration",
-                  "created_at": now, "updated_at": now,
-              })
-              print(f"    created  platform-admin (id={role_id})")
-
-          # ── 3. Role–permission links ─────────────────────────────────────────
-          print("\n3. Role–permission links")
-          ROLE_PK = env_key(f"ROLE#{role_id}")
-          old = roles_tbl.query(
-              KeyConditionExpression=Key("pk").eq(ROLE_PK) & Key("sk").begins_with("PERM#")
-          )
-          for item in old.get("Items", []):
-              roles_tbl.delete_item(Key={"pk": item["pk"], "sk": item["sk"]})
-          for pkey in permission_keys:
-              roles_tbl.put_item(Item={
-                  "pk": ROLE_PK, "sk": f"PERM#{pkey}",
-                  "role_id": role_id, "permission_key": pkey,
-                  "tenant_id": "platform", "assigned_at": now,
-              })
-          print(f"    set {len(permission_keys)} permissions on platform-admin")
-
-          # ── 4. Claim mapping config ──────────────────────────────────────────
-          print("\n4. Claim mapping config")
-          MAPPING_SOURCE = {
-              "schema_version": "2.0",
-              "fields": [{"name": "roles", "source": "https://porth.io/roles",
-                          "type": "collection", "required": False,
-                          "ops": [{"op": "resolve_roles"}]}],
-              "default_roles": [],
-          }
-          COMPILED_SOURCE = (
-              "# AUTO-GENERATED by claim_mapping_codegen — config hash c9845fb83254fbc8\n"
-              "# DO NOT EDIT manually. Re-generate from the mapping config.\n"
-              "from __future__ import annotations\n"
-              "from typing import Any\n"
-              "from porth_common.services.exceptions import MappingError\n"
-              "\n"
-              "def _get_path(obj: dict, path: str) -> Any:\n"
-              '    """OIDC-aware dot-notation path resolver."""\n'
-              "    if not isinstance(obj, dict) or not path:\n"
-              "        return None\n"
-              '    if path.startswith(("http://", "https://")):\n'
-              "        return obj.get(path)\n"
-              '    parts = path.split(".")\n'
-              "    current: Any = obj\n"
-              "    for part in parts:\n"
-              "        if not isinstance(current, dict):\n"
-              "            return None\n"
-              "        current = current.get(part)\n"
-              "        if current is None:\n"
-              "            return None\n"
-              "    return current\n"
-              "\n"
-              "def map_claims(claims: dict, role_registry: dict | None = None) -> dict:\n"
-              '    """Map JWT claims to user model fields.\n'
-              "    \n"
-              "    Args:\n"
-              "        claims: Raw JWT claims dict from identity provider.\n"
-              "        role_registry: Optional dict mapping source_key values to role IDs.\n"
-              "            Required for fields with resolve_roles op.\n"
-              "    Returns:\n"
-              "        Dict of {field_name: transformed_value}.\n"
-              "    Raises:\n"
-              "        MappingError: If a required claim is absent.\n"
-              '    """\n'
-              "    result: dict = {}\n"
-              "\n"
-              "    # field: roles (collection)\n"
-              "    _v = claims.get('https://porth.io/roles')\n"
-              "    if _v is not None:\n"
-              "        if not isinstance(_v, list):\n"
-              "            _v = [_v]\n"
-              "        _collection = []\n"
-              "        for _elem in _v:\n"
-              "            _ev = _elem\n"
-              "            # resolve_roles: match against role registry\n"
-              "            if _ev is not None and role_registry is not None:\n"
-              "                _ev = role_registry.get(str(_ev))\n"
-              "            if _ev is not None:\n"
-              "                _collection.append(_ev)\n"
-              "        result['roles'] = list(dict.fromkeys(_collection))\n"
-              "\n"
-              "    return result\n"
-          )
-          COMPILED_HASH = "55016a468cbb18927879e32725927fc3d501a7887918f05eed50911918fd6855"
-
-          existing_cfg = claim_tbl.query(
-              KeyConditionExpression=Key("PK").eq(PLATFORM_PK),
-              ScanIndexForward=False, Limit=1,
-          )
-          if existing_cfg.get("Items"):
-              latest = existing_cfg["Items"][0]
-              if latest.get("compiled_hash") == COMPILED_HASH:
-                  print(f"    exists   claim mapping config v{latest['version']} (no change)")
-              else:
-                  version = latest["version"] + 1
-                  claim_tbl.put_item(Item={
-                      "PK": PLATFORM_PK, "SK": f"VERSION#{version:06d}",
-                      "gsi1pk": PLATFORM_PK, "gsi1sk": f"VERSION#{version:06d}",
-                      "id": str(uuid.uuid4()), "tenant_id": "platform", "version": version,
-                      "mapping_source": MAPPING_SOURCE, "compiled_source": COMPILED_SOURCE,
-                      "compiled_hash": COMPILED_HASH,
-                      "compiled_at": now, "created_at": now, "updated_at": now,
-                  })
-                  print(f"    saved    claim mapping config v{version}")
-          else:
-              claim_tbl.put_item(Item={
-                  "PK": PLATFORM_PK, "SK": "VERSION#000001",
-                  "gsi1pk": PLATFORM_PK, "gsi1sk": "VERSION#000001",
-                  "id": str(uuid.uuid4()), "tenant_id": "platform", "version": 1,
-                  "mapping_source": MAPPING_SOURCE, "compiled_source": COMPILED_SOURCE,
-                  "compiled_hash": COMPILED_HASH,
-                  "compiled_at": now, "created_at": now, "updated_at": now,
-              })
-              print("    saved    claim mapping config v1")
-
-          print("\n✅ Platform tenant bootstrap complete")
-          PYEOF
+          python3 scripts/bootstrap_platform_tenant.py
+          echo "✅ Platform tenant bootstrapped under ENV#${ENV_SCOPE}#"
 
       - name: Patch platform tenant IdP config (direct DynamoDB)
         # PORTH-532: was `PATCH /tenants/platform` with a retry loop. That is

--- a/scripts/bootstrap_platform_tenant.py
+++ b/scripts/bootstrap_platform_tenant.py
@@ -13,17 +13,29 @@ Direct DynamoDB writes are required because the Porth API itself calls
 assert_active(tenant_id) which requires TENANT#platform to already exist —
 bootstrapping via the API would be circular.
 
+ADR-Z8 environment scoping (PORTH-532)
+--------------------------------------
+When ``PORTH_ENV_SCOPE`` is set, every **partition** key is written as
+``ENV#{scope}#…``. This must match the Porth install's ``FixedEnvironment``
+(single-env) or the target slot (multi-env): an authorizer pinned to ``prod``
+resolves ``ENV#prod#TENANT#platform`` and simply will not see an unscoped record
+(PORTH-514 — the failure is silent, the tenant just appears not to exist).
+
+Leaving it unset preserves the previous unscoped behaviour byte-for-byte.
+
 Table names are resolved from env vars:
     PORTH_TENANTS_TABLE
     PORTH_PERMISSIONS_TABLE
     PORTH_ROLES_TABLE
     PORTH_CLAIM_MAPPING_CONFIGS_TABLE
+    PORTH_ENV_SCOPE   (optional; e.g. "prod")
 
 Usage (local):
     PORTH_TENANTS_TABLE=porth-tenants-dev \\
     PORTH_PERMISSIONS_TABLE=porth-permissions-dev \\
     PORTH_ROLES_TABLE=porth-roles-dev \\
     PORTH_CLAIM_MAPPING_CONFIGS_TABLE=porth-claim-mapping-configs-dev \\
+    PORTH_ENV_SCOPE=prod \\
     AWS_REGION=us-east-1 python3 scripts/bootstrap_platform_tenant.py
 """
 
@@ -42,6 +54,10 @@ from boto3.dynamodb.conditions import Key
 
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 APP_NS = "porth-platform"
+
+# ADR-Z8 data axis. Distinct from the table-name suffix (dev/staging) — conflating
+# the two writes records the authorizer never looks for.
+ENV_SCOPE = os.environ.get("PORTH_ENV_SCOPE", "").strip()
 
 PERMISSIONS = [
     {"key": "platform.tenants.read",   "display_name": "View Tenants",           "category": "Tenants",       "sort_order": 10},
@@ -132,6 +148,25 @@ COMPILED_HASH = "55016a468cbb18927879e32725927fc3d501a7887918f05eed50911918fd685
 
 
 # ---------------------------------------------------------------------------
+# ADR-Z8 key scoping
+# ---------------------------------------------------------------------------
+
+def env_key(base: str) -> str:
+    """Apply the ADR-Z8 environment prefix to a *partition* key string.
+
+    Mirrors ``porth_common.providers.aws.repositories.base._env_key``: the environment is
+    folded into the **content** of the partition key attribute (``PK``/``pk`` and
+    ``gsiNpk``) — never the table ``KeySchema`` — so it triggers no table replace.
+
+    Apply only to partition (hash) keys, never sort keys: environment is an outer
+    partition axis, so prefixing a sort key would be wrong.
+
+    Returns ``base`` unchanged when no scope is bound, preserving single-env behaviour.
+    """
+    return f"ENV#{ENV_SCOPE}#{base}" if ENV_SCOPE else base
+
+
+# ---------------------------------------------------------------------------
 # Bootstrap helpers
 # ---------------------------------------------------------------------------
 
@@ -140,27 +175,29 @@ def utc_now() -> str:
 
 
 def bootstrap_platform_org_and_tenant(tenants_tbl, now: str) -> str:
-    existing = tenants_tbl.get_item(Key={"PK": "TENANT#platform", "SK": "METADATA"})
+    platform_pk = env_key("TENANT#platform")
+    existing = tenants_tbl.get_item(Key={"PK": platform_pk, "SK": "METADATA"})
     if "Item" in existing:
         org_id = existing["Item"]["org_id"]
-        print(f"    exists   TENANT#platform (org_id={org_id})")
+        print(f"    exists   {platform_pk} (org_id={org_id})")
         return org_id
 
     org_id = str(uuid.uuid4())
     tenants_tbl.put_item(Item={
-        "PK": f"ORG#{org_id}", "SK": "METADATA",
-        "gsi1pk": "ORG_SLUG#platform", "gsi1sk": "METADATA",
+        "PK": env_key(f"ORG#{org_id}"), "SK": "METADATA",
+        "gsi1pk": env_key("ORG_SLUG#platform"), "gsi1sk": "METADATA",
         "id": org_id, "name": "Platform", "slug": "platform",
         "status": "active", "created_at": now, "updated_at": now,
     })
     tenants_tbl.put_item(Item={
-        "PK": "TENANT#platform", "SK": "METADATA",
-        "gsi1pk": f"ORG#{org_id}", "gsi1sk": "TENANT#platform",
+        "PK": platform_pk, "SK": "METADATA",
+        "gsi1pk": env_key(f"ORG#{org_id}"), "gsi1sk": "TENANT#platform",
         "tenant_id": "platform", "org_id": org_id, "org_name": "Platform",
-        "display_name": "Platform", "environment_type": "production",
+        # PORTH-502: environment_type was renamed tenant_tier.
+        "display_name": "Platform", "tenant_tier": "production",
         "status": "active", "created_at": now, "updated_at": now,
     })
-    print(f"    created  ORG#{org_id} + TENANT#platform")
+    print(f"    created  {env_key(f'ORG#{org_id}')} + {platform_pk}")
     return org_id
 
 
@@ -168,8 +205,8 @@ def bootstrap_permissions(perms_tbl, now: str) -> list[str]:
     permission_keys: list[str] = []
     for p in PERMISSIONS:
         perms_tbl.put_item(Item={
-            "pk": f"TENANT#platform#NS#{APP_NS}", "sk": f"PERM#{p['key']}",
-            "gsi1pk": "TENANT#platform", "gsi1sk": f"CAT#{p['category']}#PERM#{p['key']}",
+            "pk": env_key(f"TENANT#platform#NS#{APP_NS}"), "sk": f"PERM#{p['key']}",
+            "gsi1pk": env_key("TENANT#platform"), "gsi1sk": f"CAT#{p['category']}#PERM#{p['key']}",
             "id": str(uuid.uuid4()), "key": p["key"], "display_name": p["display_name"],
             "category": p["category"], "app_namespace": APP_NS,
             "tenant_id": "platform", "sort_order": p["sort_order"],
@@ -181,15 +218,16 @@ def bootstrap_permissions(perms_tbl, now: str) -> list[str]:
 
 
 def bootstrap_role(roles_tbl, now: str) -> str:
+    platform_pk = env_key("TENANT#platform")
     resp = roles_tbl.query(
-        KeyConditionExpression=Key("pk").eq("TENANT#platform") & Key("sk").begins_with("ROLE#")
+        KeyConditionExpression=Key("pk").eq(platform_pk) & Key("sk").begins_with("ROLE#")
     )
     for item in resp.get("Items", []):
         if item.get("name") == "platform-admin":
             role_id = item["id"]
             if item.get("source_key") != "platform-admin":
                 roles_tbl.update_item(
-                    Key={"pk": "TENANT#platform", "sk": f"ROLE#{role_id}"},
+                    Key={"pk": platform_pk, "sk": f"ROLE#{role_id}"},
                     UpdateExpression="SET source_key = :sk, updated_at = :ua",
                     ExpressionAttributeValues={":sk": "platform-admin", ":ua": now},
                 )
@@ -200,7 +238,7 @@ def bootstrap_role(roles_tbl, now: str) -> str:
 
     role_id = str(uuid.uuid4())
     roles_tbl.put_item(Item={
-        "pk": "TENANT#platform", "sk": f"ROLE#{role_id}",
+        "pk": platform_pk, "sk": f"ROLE#{role_id}",
         "id": role_id, "tenant_id": "platform", "name": "platform-admin",
         "is_system": True, "source_key": "platform-admin",
         "description": "System role for platform-level tenant administration",
@@ -211,9 +249,10 @@ def bootstrap_role(roles_tbl, now: str) -> str:
 
 
 def bootstrap_role_permissions(roles_tbl, role_id: str, permission_keys: list[str], now: str) -> None:
+    role_pk = env_key(f"ROLE#{role_id}")
     # Remove old links
     old = roles_tbl.query(
-        KeyConditionExpression=Key("pk").eq(f"ROLE#{role_id}") & Key("sk").begins_with("PERM#")
+        KeyConditionExpression=Key("pk").eq(role_pk) & Key("sk").begins_with("PERM#")
     )
     for item in old.get("Items", []):
         roles_tbl.delete_item(Key={"pk": item["pk"], "sk": item["sk"]})
@@ -221,7 +260,7 @@ def bootstrap_role_permissions(roles_tbl, role_id: str, permission_keys: list[st
     # Write new links
     for pkey in permission_keys:
         roles_tbl.put_item(Item={
-            "pk": f"ROLE#{role_id}", "sk": f"PERM#{pkey}",
+            "pk": role_pk, "sk": f"PERM#{pkey}",
             "role_id": role_id, "permission_key": pkey,
             "tenant_id": "platform", "assigned_at": now,
         })
@@ -229,8 +268,9 @@ def bootstrap_role_permissions(roles_tbl, role_id: str, permission_keys: list[st
 
 
 def bootstrap_claim_mapping_config(claim_tbl, now: str) -> None:
+    platform_pk = env_key("TENANT#platform")
     existing_cfg = claim_tbl.query(
-        KeyConditionExpression=Key("PK").eq("TENANT#platform"),
+        KeyConditionExpression=Key("PK").eq(platform_pk),
         ScanIndexForward=False,
         Limit=1,
     )
@@ -244,8 +284,8 @@ def bootstrap_claim_mapping_config(claim_tbl, now: str) -> None:
         version = 1
 
     claim_tbl.put_item(Item={
-        "PK": "TENANT#platform", "SK": f"VERSION#{version:06d}",
-        "gsi1pk": "TENANT#platform", "gsi1sk": f"VERSION#{version:06d}",
+        "PK": platform_pk, "SK": f"VERSION#{version:06d}",
+        "gsi1pk": platform_pk, "gsi1sk": f"VERSION#{version:06d}",
         "id": str(uuid.uuid4()), "tenant_id": "platform", "version": version,
         "mapping_source": MAPPING_SOURCE, "compiled_source": COMPILED_SOURCE,
         "compiled_hash": COMPILED_HASH,
@@ -268,7 +308,10 @@ def main() -> None:
 
     now = utc_now()
 
-    print("Bootstrapping platform tenant")
+    if ENV_SCOPE:
+        print(f"Bootstrapping platform tenant (ADR-Z8 scope: ENV#{ENV_SCOPE}#…)")
+    else:
+        print("Bootstrapping platform tenant (unscoped — PORTH_ENV_SCOPE not set)")
 
     print("\n0. Platform org + tenant")
     bootstrap_platform_org_and_tenant(tenants_tbl, now)


### PR DESCRIPTION
## PORTH-532 · Epic PORTH-494 · ADR-Z8 / ADR-Z9

**This is what currently stops login working end-to-end on EMS.** The 0.1.16 upgrade (#52) deliberately left the bootstrap and IdP-patch steps untouched; this fixes them, plus the stale `reset-env.yml`.

### Root cause
`scripts/bootstrap_platform_tenant.py` wrote every partition key **unscoped** (`TENANT#platform`, `ORG#…`, `ROLE#…`). The install now runs `EnvironmentMode=single` / `FixedEnvironment=prod`, so the authorizer resolves `ENV#prod#TENANT#platform` and never sees it (PORTH-514). The install reports success while the platform tenant is effectively invisible — a silent failure.

### Changes

**`scripts/bootstrap_platform_tenant.py`** — the shared fix
- `PORTH_ENV_SCOPE` drives an `env_key()` helper mirroring `porth_common…base._env_key`: the environment is folded into the **content** of the partition key (`PK`/`pk` and `gsi1pk`), never the `KeySchema`, and **never** applied to sort keys (environment is an outer partition axis).
- Unset/empty scope preserves the previous unscoped behaviour **byte-for-byte**, so a multi-env or pre-ADR-Z8 install is unaffected.
- `environment_type` → `tenant_tier` (PORTH-502).

**`porth-install.yml`** — the two steps left out of #52
- Bootstrap now passes `PORTH_ENV_SCOPE=${EFF_FIXED_ENV}`.
- IdP patch writes at the env-scoped key in the **neutral OIDC** shape (`issuer` + `jwks_uri`, PORTH-488) and sets `tenant_tier`.

**`reset-env.yml`** — six staleness fixes
| # | Was | Now |
|---|---|---|
| 1 | stack `porth-components` | `serverlessrepo-porth-components` (every lookup returned `""`) |
| 2 | omitted `porth-sessions-*` | included — sessions survived a "full" reset |
| 3 | unscoped bootstrap | `ENV#{scope}#` via the shared script |
| 4 | legacy Auth0 idp shape | neutral OIDC |
| 5 | `environment_type` | `tenant_tier` |
| 6 | `secrets.AWS_ROLE_ARN` | `vars.AWS_ROLE_ARN` (matches porth-install) |

Also: the IdP patch moved from `PATCH /tenants/platform` to a direct DynamoDB write — the API path is chicken-and-egg during a reset (it needs a working authorizer, which is exactly what a broken platform tenant prevents), so the retry loop is gone. Stack-output resolution now **fails loudly** instead of silently no-opping on an empty value — that silence is why this was broken unnoticed.

**De-duplication:** `reset-env.yml` carried its own inline copy of the bootstrap. Both workflows now call the one script, so the scoping fix can't drift. That file drops 22.9KB → 10.3KB.

### Verification
`py_compile` ✅ · `env_key()` unit-checked both ways — `ENV#prod#TENANT#platform` when scoped, unchanged when not ✅ · `tenant_tier` replaces `environment_type` (only remaining mention is the explanatory comment) ✅ · both workflow YAMLs parse ✅

Not dispatched. Suggested order once merged: **reset-env** → verify the platform tenant at `ENV#prod#…` → **porth-install** (re-run, idempotent) → admin UI sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)