### PR TITLE
fix(qa-tools): seeder wrote an invalid tenant_tier — write-valid, read-fatal (PORTH-543)

### DIFF
--- a/infra/qa-tools/src/seed/handler.py
+++ b/infra/qa-tools/src/seed/handler.py
@@ -12,7 +12,7 @@ POST /qa/seed with a JSON body (the manifest):
         {
           "tenant_id": "acme",
           "display_name": "Acme Corp",
-          "tenant_tier": "standard",
+          "tenant_tier": "sandbox",             // optional; one of TENANT_TIERS
           "porth_org_id": "ems",                // org slug — find-or-create, resolved to a UUID
           "provider_org_id": "org_XXXX",        // Auth0 Organization id (required for tenant login)
           "reserved_for_e2e": false,            // true => skipped, the slot is left for the e2e test
@@ -79,6 +79,20 @@ TESTBED_CONFIG_PARAM = "/porth/config/testbed"
 TESTBED_MANIFEST_PARAM = "/porth/testbed/tenants"
 
 _TENANT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,62}$")
+
+# Must mirror the pattern on porth_common.models.tenant.Tenant.tenant_tier. DynamoDB
+# validates nothing, so a tier outside this set writes cleanly and then fails on every
+# READ — the API cannot build a Tenant from the row and answers 400 on
+# GET /tenants/organization/{id}. The seeder reports `created`, and the tenant is simply
+# invisible in the admin UI with no error anywhere in the chain.
+#
+# PORTH-502 renamed environment_type -> tenant_tier and changed the allowed values with
+# it. The old default "standard" was carried through unchanged, so every tenant this
+# seeder has ever written was unreadable. Validated here as well as defaulted, so a bad
+# value in the manifest fails the dry run rather than surfacing days later as a missing
+# row.
+TENANT_TIERS = ("production", "staging", "development", "sandbox")
+DEFAULT_TENANT_TIER = "sandbox"
 
 
 def handler(event, context):
@@ -266,6 +280,13 @@ def _validate_tenant(t) -> list:
                         f"its row lookup is a substring match and would target the wrong tenant"
                     )
 
+    tier = t.get("tenant_tier")
+    if tier is not None and tier not in TENANT_TIERS:
+        problems.append(
+            f"tenant_tier '{tier}' is not one of {', '.join(TENANT_TIERS)} — the row would "
+            f"write cleanly and then 400 on every read"
+        )
+
     problems.extend(_validate_admin(t.get("admin"), "admin"))
     problems.extend(_validate_idp(t.get("idp"), "idp"))
     return problems
@@ -323,8 +344,9 @@ def _seed_tenant(t, tables, secrets, env_scope, dry_run) -> dict:
         "org_id": org_uuid,
         "org_name": t.get("porth_org_id") or tid,
         "display_name": t.get("display_name") or tid,
-        # PORTH-502 renamed environment_type -> tenant_tier.
-        "tenant_tier": t.get("tenant_tier") or "standard",
+        # PORTH-502 renamed environment_type -> tenant_tier. The default must be a member
+        # of TENANT_TIERS — see the note there; an invalid tier is write-valid, read-fatal.
+        "tenant_tier": t.get("tenant_tier") or DEFAULT_TENANT_TIER,
         "status": "active",
         "idp_config_override": idp_config,
         "admin_email": admin["email"],

--- a/infra/qa-tools/testbed-manifest.example.json
+++ b/infra/qa-tools/testbed-manifest.example.json
@@ -43,7 +43,7 @@
     {
       "tenant_id": "acme",
       "display_name": "Acme Corporation",
-      "tenant_tier": "standard",
+      "tenant_tier": "sandbox",
       "porth_org_id": "ems",
       "provider_org_id": "org_REPLACE_WITH_AUTH0_ORG_ID",
       "idp": {
@@ -61,7 +61,7 @@
     {
       "tenant_id": "globex",
       "display_name": "Globex Industries",
-      "tenant_tier": "standard",
+      "tenant_tier": "sandbox",
       "porth_org_id": "ems",
       "provider_org_id": "org_REPLACE_WITH_AUTH0_ORG_ID",
       "idp": {
@@ -84,7 +84,7 @@
       ],
       "tenant_id": "initech",
       "display_name": "Initech",
-      "tenant_tier": "enterprise",
+      "tenant_tier": "development",
       "porth_org_id": "ems",
       "idp": {
         "issuer": "https://kc.ems.estynsoftware.test/realms/porth",

--- a/infra/qa-tools/tests/test_seed.py
+++ b/infra/qa-tools/tests/test_seed.py
@@ -61,7 +61,7 @@ PLATFORM = {
 TENANT = {
     "tenant_id": "acme",
     "display_name": "Acme Corp",
-    "tenant_tier": "standard",
+    "tenant_tier": "sandbox",
     "porth_org_id": "ems",
     "provider_org_id": "org_TESTTESTTESTTEST",
     "idp": dict(AUTH0_IDP),
@@ -309,8 +309,44 @@ def test_writes_tenant_tier_not_environment_type(env):
     """PORTH-502 renamed the field."""
     tenant = _seed(env) and env.store["porth-tenants-dev"][("ENV#prod#TENANT#acme", "METADATA")]
 
-    assert tenant["tenant_tier"] == "standard"
+    assert tenant["tenant_tier"] == "sandbox"
     assert "environment_type" not in tenant
+
+
+def test_written_tier_is_one_the_porth_model_accepts(env):
+    """The rename this file already covers changed the allowed VALUES too.
+
+    Asserting only that the field is *named* `tenant_tier` is what let the invalid default
+    "standard" survive PORTH-502. DynamoDB accepted it, the seeder reported `created`, and
+    the row then 400'd on every read because the API could not build a Tenant from it —
+    invisible in the admin UI, no error anywhere in the chain. Pin the value, not the key.
+    """
+    import handler
+
+    _seed(env)
+    tenant = env.store["porth-tenants-dev"][("ENV#prod#TENANT#acme", "METADATA")]
+
+    assert tenant["tenant_tier"] in handler.TENANT_TIERS
+
+
+def test_tier_defaults_to_a_valid_value_when_the_manifest_omits_it(env):
+    """The live manifest sets no tier, so the default is the path that actually runs."""
+    import handler
+
+    _seed(env, tenant_tier=None)
+    tenant = env.store["porth-tenants-dev"][("ENV#prod#TENANT#acme", "METADATA")]
+
+    assert tenant["tenant_tier"] == handler.DEFAULT_TENANT_TIER
+    assert handler.DEFAULT_TENANT_TIER in handler.TENANT_TIERS
+
+
+def test_rejects_a_tier_outside_the_set_the_model_allows(env):
+    """Fail in the dry run, not days later as a row that will not render."""
+    result = _seed(env, tenant_tier="enterprise")
+
+    assert result["error"] == "Manifest validation failed"
+    assert any("tenant_tier" in d for d in result["details"])
+    assert env.store.get("porth-tenants-dev", {}) == {}
 
 
 def test_idp_config_is_written_verbatim_from_the_tenant(env):


### PR DESCRIPTION
Closes PORTH-543. Found while chasing "`ems-test` was seeded but doesn't appear in the platform admin UI" on the EMS reference install.

## The bug

The seeder defaulted `tenant_tier` to `"standard"`, which is not in the set the Porth model allows:

```
^(production|staging|development|sandbox)$
```

PORTH-502 renamed `environment_type` → `tenant_tier` **and changed the allowed values with it**. The fallback was carried through unchanged.

## Why nothing caught it

DynamoDB validates nothing, so the row wrote cleanly and the seeder reported `created`. The failure is entirely on the **read** side — the API can't build a `Tenant` from the row and answers 400 on `GET /tenants/organization/{id}`:

```json
{"detail": "1 validation error for Tenant\ntenant_tier\n  String should match pattern
 '^(production|staging|development|sandbox)$' [input_value='standard']"}
```

The admin SPA fetches tenants per organization and swallows per-org failures:

```js
tenantsApi.listByOrg(org.id).catch(() => [] as TenantRow[])
```

So a 400 renders as "that org has no tenants". Seed green, table populated, screen empty, nothing in the console. Diagnosed from the network panel — the org came back from `/organizations/` but its tenant fetch 400'd.

**The test suite actively pinned it in place.** `test_writes_tenant_tier_not_environment_type` asserted the field had been *renamed* and hardcoded the value to the very string that was invalid. The rename changed the allowed values too, and nothing tested those.

## Changes

| | |
|---|---|
| `src/seed/handler.py` | default → `sandbox`; `TENANT_TIERS` mirrors the model's pattern; `_validate_tenant` rejects an out-of-set value |
| `testbed-manifest.example.json` | carried `"standard"` ×2 and `"enterprise"` — all three invalid |
| `tests/test_seed.py` | fixture updated; three regression tests added |

The validation matters as much as the default: it runs in `dry_run`, so a bad manifest value now fails the plan instead of surfacing days later as a row that won't render.

The example manifest is not cosmetic — `test_the_example_manifest_validates` exists precisely because an example that doesn't validate sends an operator debugging their own copy of a shape that was never right. It was shipping one.

## Verification

42 tests pass. The new coverage was checked against the bug rather than merely written: restoring `or "standard"` makes `test_tier_defaults_to_a_valid_value_when_the_manifest_omits_it` fail. That test exercises the live path — the manifest in SSM omits the field, so the default is what actually runs.

## Deploying

`deploy-qa-tools.yml` runs on push to `main`, so merging redeploys `porth-qa-seed-dev`. Then re-run **Porth — seed testbed tenants** (`env_scope: prod`).

**No `reset-env` needed** — `_seed_tenant` calls `put_item` unconditionally, preserving only `created_at`, so re-seeding rewrites the tier on existing rows.

## Follow-up, not in this PR

The SPA's `.catch(() => [])` is the reason this took an evening rather than a minute. A per-org failure is indistinguishable from an empty org — no error, no console warning, no partial-failure indicator. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)