### PR TITLE
fix(ffug): IAM role Description must be ASCII — em dash rolled back the stack (PORTH-555)

### DIFF
--- a/.github/workflows/ffug-tests.yml
+++ b/.github/workflows/ffug-tests.yml
@@ -30,7 +30,9 @@ jobs:
           python-version: '3.12'
 
       - name: Install test dependencies
-        run: python -m pip install --quiet pytest boto3
+        # pyyaml is for the template guard below, not the tests — the runner
+        # image doesn't ship it, which is how this step earned its own commit.
+        run: python -m pip install --quiet pytest boto3 pyyaml
 
       - name: Run ffug tests
         working-directory: lambdas

--- a/.github/workflows/ffug-tests.yml
+++ b/.github/workflows/ffug-tests.yml
@@ -35,3 +35,36 @@ jobs:
       - name: Run ffug tests
         working-directory: lambdas
         run: python -m pytest ffug/tests -q
+
+      # IAM rejects any character outside the Latin-1 printable range in a
+      # role Description, notably the em dash. CloudFormation only finds out
+      # mid-deploy and rolls the whole stack back, so catch it here instead.
+      - name: Guard - IAM role descriptions are IAM-legal
+        run: |
+          python - <<'PY'
+          import re, sys, yaml
+
+          class L(yaml.SafeLoader):
+              pass
+          for tag in ('!Sub', '!Ref', '!GetAtt', '!Equals', '!If', '!Join',
+                      '!Select', '!Split', '!FindInMap', '!Not', '!And', '!Or',
+                      '!Base64', '!Condition', '!ImportValue'):
+              L.add_constructor(tag, lambda loader, node: None)
+
+          doc = yaml.load(open('template.yml'), Loader=L)
+          legal = re.compile('^[\t\n\r\x20-\x7e\xa1-\xff]*$')
+          bad = []
+          for name, res in (doc.get('Resources') or {}).items():
+              if res.get('Type') != 'AWS::IAM::Role':
+                  continue
+              desc = (res.get('Properties') or {}).get('Description')
+              if isinstance(desc, str) and not legal.match(desc):
+                  offenders = sorted({hex(ord(c)) for c in desc if not legal.match(c)})
+                  bad.append('%s: illegal %s in %r' % (name, offenders, desc))
+          if bad:
+              print('IAM role Description must be ASCII/Latin-1 only:')
+              for b in bad:
+                  print('   ' + b)
+              sys.exit(1)
+          print('OK: IAM role descriptions are IAM-legal')
+          PY

--- a/template.yml
+++ b/template.yml
@@ -176,7 +176,11 @@ Resources:
   PorthUatRunnerRole:
     Type: AWS::IAM::Role
     Properties:
-      Description: Porth ADR-Z11 UAT runner — invoke/read ffug from the Components repo's UAT workflow.
+      # ASCII only: the IAM API rejects any character outside the Latin-1
+      # printable range, which excludes the em dash this codebase uses freely
+      # in prose. Cost of learning that: one rolled-back stack (run
+      # 31216080066). The guard in ffug-tests.yml now catches it on the PR.
+      Description: "Porth ADR-Z11 UAT runner - invoke/read ffug from the Components repo's UAT workflow."
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
**Fixes the failed deploy** from [run 31216080066](https://github.com/dragoninex1le/enterprise-membership-sample/actions/runs/31216080066) (merge of #59).

### What happened

IAM rejects any character outside `[\t\n\r\x20-\x7e\xa1-\xff]` in a role `Description`. The em dash this codebase uses freely in prose is **U+2014 — outside that range**, so `PorthUatRunnerRole` failed with a 400 at create time:

```
1 validation error detected: Value at 'description' failed to satisfy constraint:
Member must satisfy regular expression pattern: [	
 -~¡-ÿ]*
```

`FfugTable`, `FfugFunctionRole` and `FfugFunction` had all reached `CREATE_COMPLETE`; CloudFormation then rolled the **entire stack** back on the one failure, so ffug is currently not deployed. Nothing was wrong with ffug itself.

### The fix

1. The description is now plain ASCII.
2. `ffug-tests.yml` gains a guard that parses `template.yml` and **fails the PR** on any IAM role `Description` outside the legal range — because CloudFormation only discovers this mid-deploy, five minutes in, and takes the stack down with it.

Verified both directions:

```
OK: IAM role descriptions are IAM-legal          # on this fix
IAM role Description must be ASCII/Latin-1 only: # with the em dash reinstated
   PorthUatRunnerRole: illegal ['0x2014'] in "…UAT runner — invoke/read ffug…"
```

ffug's 11 unit tests still pass. Merging this re-runs the deploy and should land ffug in EMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)